### PR TITLE
Updating to newest version of Amazon SDK

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/project.json
+++ b/src/Serilog.Sinks.AwsCloudWatch/project.json
@@ -23,7 +23,7 @@
 		"iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
 	},
     "dependencies": {
-        "AWSSDK.CloudWatchLogs": "3.2.8-rc",
+        "AWSSDK.CloudWatchLogs": "3.3.0",
         "Serilog": "2.0.0",
         "Serilog.Sinks.PeriodicBatching": "2.0.0",
         "Serilog.Sinks.Trace": "2.0.0"


### PR DESCRIPTION
Updating to newest version of amazon SDK.  I am using the S3 SDK elsewhere in my project and this older version is incompatible. 