### PR TITLE
add net451 targets

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/project.json
+++ b/src/Serilog.Sinks.AwsCloudWatch/project.json
@@ -29,9 +29,7 @@
         "Serilog.Sinks.Trace": "2.0.0"
     },
     "frameworks": {
-        "net451": {
-
-        },
+        "net451": {},
         "net46": {
             "dependencies": {}
         },

--- a/src/Serilog.Sinks.AwsCloudWatch/project.json
+++ b/src/Serilog.Sinks.AwsCloudWatch/project.json
@@ -29,6 +29,9 @@
         "Serilog.Sinks.Trace": "2.0.0"
     },
     "frameworks": {
+        "net451": {
+
+        },
         "net46": {
             "dependencies": {}
         },

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/project.json
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/project.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "Serilog.Sinks.AwsCloudWatch": { "target": "project" },
         "xunit": "2.2.0-beta2-build3300",
-        "dotnet-test-xunit": "1.0.0-rc2-build10025"
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
     },
     "frameworks": {
         "net451": {},

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/project.json
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/project.json
@@ -7,6 +7,8 @@
         "dotnet-test-xunit": "1.0.0-rc2-build10025"
     },
     "frameworks": {
+        "net451": {},
+        "net46": {},
         "netcoreapp1.5": {
             "imports": [
                 "dotnet5.6",


### PR DESCRIPTION
This should address #19 by adding the targets needed for mono deployments.  

A note about testing: I tried to run the unit tests before submitting this, but the restore process failed on version conflicts:

```
error: Version conflict detected for xunit.abstractions.
error:  Serilog.Sinks.AwsCloudWatch.Tests (>= 2.0.0) -> xunit (>= 2.2.0-beta2-build3300) -> xunit.core (= 2.2.0-beta2-build3300) -> xunit.extensibility.core (= 2.2.0-beta2-build3300) -> xunit.abstractions (>= 2.0.1-rc2)
error:  Serilog.Sinks.AwsCloudWatch.Tests (>= 2.0.0) -> dotnet-test-xunit (>= 1.0.0-rc2-build10025) -> xunit.runner.reporters (>= 2.1.0) -> xunit.runner.utility (= 2.1.0) -> xunit.abstractions (= 2.0.0).
```