### PR TITLE
Added RenderedMessageLogEventRenderer ctor overload

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/RenderedMessageLogEventRenderer.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/RenderedMessageLogEventRenderer.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using Serilog.Events;
+using Serilog.Formatting;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
@@ -8,13 +9,34 @@ namespace Serilog.Sinks.AwsCloudWatch
     /// </summary>
     public class RenderedMessageLogEventRenderer : ILogEventRenderer
     {
+        private readonly ITextFormatter formatter;
+
+        public RenderedMessageLogEventRenderer()
+            : this(new PlainTextFormatter())
+        {
+
+        }
+
+        public RenderedMessageLogEventRenderer(ITextFormatter formatter)
+        {
+            this.formatter = formatter;
+        }
+
         public string RenderLogEvent(LogEvent logEvent)
         {
             using (var writer = new StringWriter())
             {
-                logEvent.RenderMessage(writer);
+                this.formatter.Format(logEvent, writer);
                 return writer.ToString();
             }
+        }
+    }
+
+    internal sealed class PlainTextFormatter : ITextFormatter
+    {
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            logEvent.RenderMessage(output);
         }
     }
 }


### PR DESCRIPTION
Added `RenderedMessageLogEventRenderer` constructor overload which allows using different ITextFormatters.

With this overload the following is possible:

```csharp

var options = new CloudWatchSinkOptions
    {
        LogGroupName = "myGroup",
        LogEventRenderer = new RenderedMessageLogEventRenderer(new JsonFormatter())
    };

var client = new AmazonCloudWatchLogsClient();

Log.Logger = new LoggerConfiguration()
              .WriteTo.AmazonCloudWatch(options, client)
              .CreateLogger();

```

Example `CloudWatch` output:

![image](https://cloud.githubusercontent.com/assets/10754345/23126744/76523888-f778-11e6-928e-3f91803a9976.png)


I have a feeling that it can be done differently, but I am not really familiar with Serilog's internals.

@thoean can you please take a look at this PR?