### PR TITLE
Create Overloads To Allow Configuration via AppSettings

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -4,7 +4,6 @@ using Amazon.CloudWatchLogs;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
-using static Serilog.Sinks.AwsCloudWatch.CloudWatchSinkOptions;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
@@ -50,8 +49,8 @@ namespace Serilog.Sinks.AwsCloudWatch
             string logGroupName,
             IAmazonCloudWatchLogs cloudWatchClient = null,
             ILogEventRenderer logEventRenderer = null,
-            LogEventLevel minimumLogEventLevel = DefaultMinimumLogEventLevel,
-            int batchSizeLimit = DefaultBatchSizeLimit,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null)
         {
             if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
@@ -61,7 +60,7 @@ namespace Serilog.Sinks.AwsCloudWatch
                 LogGroupName = logGroupName,
                 MinimumLogEventLevel = minimumLogEventLevel,
                 BatchSizeLimit = batchSizeLimit,
-                Period = period ?? DefaultPeriod,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer
             };
             var client = cloudWatchClient ?? new AmazonCloudWatchLogsClient();
@@ -87,8 +86,8 @@ namespace Serilog.Sinks.AwsCloudWatch
             string logGroupName,
             string regionName,
             ILogEventRenderer logEventRenderer = null,
-            LogEventLevel minimumLogEventLevel = DefaultMinimumLogEventLevel,
-            int batchSizeLimit = DefaultBatchSizeLimit,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null)
         {
             if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
@@ -99,7 +98,7 @@ namespace Serilog.Sinks.AwsCloudWatch
                 LogGroupName = logGroupName,
                 MinimumLogEventLevel = minimumLogEventLevel,
                 BatchSizeLimit = batchSizeLimit,
-                Period = period ?? DefaultPeriod,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer
             };
             var client = new AmazonCloudWatchLogsClient(RegionEndpoint.GetBySystemName(regionName));
@@ -131,8 +130,8 @@ namespace Serilog.Sinks.AwsCloudWatch
             string secretAccessKey,
             string regionName,
             ILogEventRenderer logEventRenderer = null,
-            LogEventLevel minimumLogEventLevel = DefaultMinimumLogEventLevel,
-            int batchSizeLimit = DefaultBatchSizeLimit,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null)
         {
             if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
@@ -145,7 +144,7 @@ namespace Serilog.Sinks.AwsCloudWatch
                 LogGroupName = logGroupName,
                 MinimumLogEventLevel = minimumLogEventLevel,
                 BatchSizeLimit = batchSizeLimit,
-                Period = period ?? DefaultPeriod,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer
             };
             var client = new AmazonCloudWatchLogsClient(accessKey, secretAccessKey,

--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Amazon;
 using Amazon.CloudWatchLogs;
+using Amazon.Runtime;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
@@ -37,80 +38,6 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
         /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
         /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
-        /// <param name="cloudWatchClient">An AWS CloudWatch client which includes access to AWS and AWS specific settings like the AWS region.</param>
-        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
-        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
-        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
-        public static LoggerConfiguration AmazonCloudWatch(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string logGroupName,
-            IAmazonCloudWatchLogs cloudWatchClient = null,
-            ILogEventRenderer logEventRenderer = null,
-            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
-            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
-            TimeSpan? period = null)
-        {
-            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
-
-            var options = new CloudWatchSinkOptions
-            {
-                LogGroupName = logGroupName,
-                MinimumLogEventLevel = minimumLogEventLevel,
-                BatchSizeLimit = batchSizeLimit,
-                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
-                LogEventRenderer = logEventRenderer
-            };
-            var client = cloudWatchClient ?? new AmazonCloudWatchLogsClient();
-            return loggerConfiguration.AmazonCloudWatch(options, client);
-        }
-
-        /// <summary>
-        /// Activates logging to AWS CloudWatch
-        /// </summary>
-        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
-        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
-        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
-        /// <param name="regionName">The system name of the region to which to write.</param>
-        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
-        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
-        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="regionName"/> is <see langword="null"/>.</exception>
-        public static LoggerConfiguration AmazonCloudWatch(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string logGroupName,
-            string regionName,
-            ILogEventRenderer logEventRenderer = null,
-            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
-            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
-            TimeSpan? period = null)
-        {
-            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
-            if (regionName == null) throw new ArgumentNullException(nameof(regionName));
-
-            var options = new CloudWatchSinkOptions
-            {
-                LogGroupName = logGroupName,
-                MinimumLogEventLevel = minimumLogEventLevel,
-                BatchSizeLimit = batchSizeLimit,
-                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
-                LogEventRenderer = logEventRenderer
-            };
-            var client = new AmazonCloudWatchLogsClient(RegionEndpoint.GetBySystemName(regionName));
-            return loggerConfiguration.AmazonCloudWatch(options, client);
-        }
-
-        /// <summary>
-        /// Activates logging to AWS CloudWatch
-        /// </summary>
-        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
-        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
-        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
         /// <param name="accessKey">The access key to use to access AWS CloudWatch.</param>
         /// <param name="secretAccessKey">The secret access key to use to access AWS CloudWatch.</param>
         /// <param name="regionName">The system name of the region to which to write.</param>
@@ -120,24 +47,22 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <param name="period">The period to be used when a batch upload should be triggered.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="accessKey"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="secretAccessKey"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="regionName"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// An invalid combination of <paramref name="accessKey"/>, <paramref name="secretAccessKey"/>,
+        /// and <paramref name="regionName"/> has been provided.
+        /// </exception>
         public static LoggerConfiguration AmazonCloudWatch(
             this LoggerSinkConfiguration loggerConfiguration,
             string logGroupName,
-            string accessKey,
-            string secretAccessKey,
-            string regionName,
+            string accessKey = null,
+            string secretAccessKey = null,
+            string regionName = null,
             ILogEventRenderer logEventRenderer = null,
             LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
             int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null)
         {
             if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
-            if (accessKey == null) throw new ArgumentNullException(nameof(accessKey));
-            if (secretAccessKey == null) throw new ArgumentNullException(nameof(secretAccessKey));
-            if (regionName == null) throw new ArgumentNullException(nameof(regionName));
 
             var options = new CloudWatchSinkOptions
             {
@@ -147,9 +72,52 @@ namespace Serilog.Sinks.AwsCloudWatch
                 Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer
             };
-            var client = new AmazonCloudWatchLogsClient(accessKey, secretAccessKey,
-                RegionEndpoint.GetBySystemName(regionName));
+            var client = CreateClient(accessKey, secretAccessKey, regionName);
             return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <exception cref="InvalidOperationException">
+        /// An invalid combination of <paramref name="accessKey"/>, <paramref name="secretAccessKey"/>,
+        /// and <paramref name="regionName"/> has been provided.
+        /// </exception>
+        static IAmazonCloudWatchLogs CreateClient(
+            string accessKey,
+            string secretAccessKey,
+            string regionName)
+        {
+            /* Some combinations of values are valid, but some are not.
+             * 
+             * accessKey | secretAccessKey | regionName | ->valid?
+             * ---------------------------------------------------
+             *    null   |       null      |    null    |    yes
+             *    null   |       null      |   value    |    yes
+             *    null   |      value      |    null    |     no
+             *    null   |      value      |   value    |     no
+             *   value   |       null      |    null    |     no
+             *   value   |       null      |   value    |     no
+             *   value   |      value      |    null    |     no
+             *   value   |      value      |   value    |    yes
+             */
+
+            if (regionName != null)
+            {
+                var region = RegionEndpoint.GetBySystemName(regionName);
+                if (accessKey != null && secretAccessKey != null)
+                {
+                    var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
+                    return new AmazonCloudWatchLogsClient(credentials, region);
+                }
+                return new AmazonCloudWatchLogsClient(region);
+            }
+
+            if (accessKey == null && secretAccessKey == null)
+            {
+                return new AmazonCloudWatchLogsClient();
+            }
+
+            // If an invalid combination has been provided, yell.
+            throw new InvalidOperationException(
+                @"An invalid combination of ""accessKey"", ""secretAccessKey"", and ""regionName"" has been provided.");
         }
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -95,7 +95,7 @@ namespace Serilog.Sinks.AwsCloudWatch
              *    null   |      value      |   value    |     no
              *   value   |       null      |    null    |     no
              *   value   |       null      |   value    |     no
-             *   value   |      value      |    null    |     no
+             *   value   |      value      |    null    |    yes
              *   value   |      value      |   value    |    yes
              */
 
@@ -108,6 +108,12 @@ namespace Serilog.Sinks.AwsCloudWatch
                     return new AmazonCloudWatchLogsClient(credentials, region);
                 }
                 return new AmazonCloudWatchLogsClient(region);
+            }
+
+            if (accessKey != null && secretAccessKey != null)
+            {
+                var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
+                return new AmazonCloudWatchLogsClient(credentials);
             }
 
             if (accessKey == null && secretAccessKey == null)

--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using Amazon;
 using Amazon.CloudWatchLogs;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
+using static Serilog.Sinks.AwsCloudWatch.CloudWatchSinkOptions;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
@@ -25,9 +27,130 @@ namespace Serilog.Sinks.AwsCloudWatch
 
             // create the sink
             ILogEventSink sink = new CloudWatchLogSink(cloudWatchClient, options);
-            
+
             // register the sink
             return loggerConfiguration.Sink(sink, options.MinimumLogEventLevel);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="cloudWatchClient">An AWS CloudWatch client which includes access to AWS and AWS specific settings like the AWS region.</param>
+        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
+            IAmazonCloudWatchLogs cloudWatchClient = null,
+            ILogEventRenderer logEventRenderer = null,
+            LogEventLevel minimumLogEventLevel = DefaultMinimumLogEventLevel,
+            int batchSizeLimit = DefaultBatchSizeLimit,
+            TimeSpan? period = null)
+        {
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? DefaultPeriod,
+                LogEventRenderer = logEventRenderer
+            };
+            var client = cloudWatchClient ?? new AmazonCloudWatchLogsClient();
+            return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="regionName">The system name of the region to which to write.</param>
+        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="regionName"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
+            string regionName,
+            ILogEventRenderer logEventRenderer = null,
+            LogEventLevel minimumLogEventLevel = DefaultMinimumLogEventLevel,
+            int batchSizeLimit = DefaultBatchSizeLimit,
+            TimeSpan? period = null)
+        {
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+            if (regionName == null) throw new ArgumentNullException(nameof(regionName));
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? DefaultPeriod,
+                LogEventRenderer = logEventRenderer
+            };
+            var client = new AmazonCloudWatchLogsClient(RegionEndpoint.GetBySystemName(regionName));
+            return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="accessKey">The access key to use to access AWS CloudWatch.</param>
+        /// <param name="secretAccessKey">The secret access key to use to access AWS CloudWatch.</param>
+        /// <param name="regionName">The system name of the region to which to write.</param>
+        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accessKey"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="secretAccessKey"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="regionName"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
+            string accessKey,
+            string secretAccessKey,
+            string regionName,
+            ILogEventRenderer logEventRenderer = null,
+            LogEventLevel minimumLogEventLevel = DefaultMinimumLogEventLevel,
+            int batchSizeLimit = DefaultBatchSizeLimit,
+            TimeSpan? period = null)
+        {
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+            if (accessKey == null) throw new ArgumentNullException(nameof(accessKey));
+            if (secretAccessKey == null) throw new ArgumentNullException(nameof(secretAccessKey));
+            if (regionName == null) throw new ArgumentNullException(nameof(regionName));
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? DefaultPeriod,
+                LogEventRenderer = logEventRenderer
+            };
+            var client = new AmazonCloudWatchLogsClient(accessKey, secretAccessKey,
+                RegionEndpoint.GetBySystemName(regionName));
+            return loggerConfiguration.AmazonCloudWatch(options, client);
         }
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -47,15 +47,62 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <param name="period">The period to be used when a batch upload should be triggered.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
-        /// <exception cref="InvalidOperationException">
-        /// An invalid combination of <paramref name="accessKey"/>, <paramref name="secretAccessKey"/>,
-        /// and <paramref name="regionName"/> has been provided.
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accessKey"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="secretAccessKey"/> is <see langword="null"/>.</exception>
         public static LoggerConfiguration AmazonCloudWatch(
             this LoggerSinkConfiguration loggerConfiguration,
             string logGroupName,
-            string accessKey = null,
-            string secretAccessKey = null,
+            string accessKey,
+            string secretAccessKey,
+            string regionName = null,
+            ILogEventRenderer logEventRenderer = null,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
+            TimeSpan? period = null)
+        {
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+            if (accessKey == null) { throw new ArgumentNullException(nameof(accessKey)); }
+            if (secretAccessKey == null) { throw new ArgumentNullException(nameof(secretAccessKey)); }
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
+                LogEventRenderer = logEventRenderer
+            };
+
+            var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
+            IAmazonCloudWatchLogs client;
+            if (regionName != null)
+            {
+                var region = RegionEndpoint.GetBySystemName(regionName);
+                client = new AmazonCloudWatchLogsClient(credentials, region);
+            }
+            else
+            {
+                client = new AmazonCloudWatchLogsClient(credentials);
+            }
+            return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="regionName">The system name of the region to which to write.</param>
+        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
             string regionName = null,
             ILogEventRenderer logEventRenderer = null,
             LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
@@ -72,58 +119,18 @@ namespace Serilog.Sinks.AwsCloudWatch
                 Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer
             };
-            var client = CreateClient(accessKey, secretAccessKey, regionName);
-            return loggerConfiguration.AmazonCloudWatch(options, client);
-        }
 
-        /// <exception cref="InvalidOperationException">
-        /// An invalid combination of <paramref name="accessKey"/>, <paramref name="secretAccessKey"/>,
-        /// and <paramref name="regionName"/> has been provided.
-        /// </exception>
-        static IAmazonCloudWatchLogs CreateClient(
-            string accessKey,
-            string secretAccessKey,
-            string regionName)
-        {
-            /* Some combinations of values are valid, but some are not.
-             * 
-             * accessKey | secretAccessKey | regionName | ->valid?
-             * ---------------------------------------------------
-             *    null   |       null      |    null    |    yes
-             *    null   |       null      |   value    |    yes
-             *    null   |      value      |    null    |     no
-             *    null   |      value      |   value    |     no
-             *   value   |       null      |    null    |     no
-             *   value   |       null      |   value    |     no
-             *   value   |      value      |    null    |    yes
-             *   value   |      value      |   value    |    yes
-             */
-
+            IAmazonCloudWatchLogs client;
             if (regionName != null)
             {
                 var region = RegionEndpoint.GetBySystemName(regionName);
-                if (accessKey != null && secretAccessKey != null)
-                {
-                    var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
-                    return new AmazonCloudWatchLogsClient(credentials, region);
-                }
-                return new AmazonCloudWatchLogsClient(region);
+                client = new AmazonCloudWatchLogsClient(region);
             }
-
-            if (accessKey != null && secretAccessKey != null)
+            else
             {
-                var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
-                return new AmazonCloudWatchLogsClient(credentials);
+                client = new AmazonCloudWatchLogsClient();
             }
-
-            if (accessKey == null && secretAccessKey == null)
-            {
-                return new AmazonCloudWatchLogsClient();
-            }
-
-            // If an invalid combination has been provided, yell.
-            throw new InvalidOperationException(
-                @"An invalid combination of ""accessKey"", ""secretAccessKey"", and ""regionName"" has been provided.");
+            return loggerConfiguration.AmazonCloudWatch(options, client);
         }
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using Serilog.Events;
-using static Serilog.Events.LogEventLevel;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
@@ -12,7 +11,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <summary>
         /// The default minimum log event level required in order to write an event to the sink.
         /// </summary>
-        public const LogEventLevel DefaultMinimumLogEventLevel = Information;
+        public const LogEventLevel DefaultMinimumLogEventLevel = LogEventLevel.Information;
 
         /// <summary>
         /// The default batch size to be used when uploading logs to AWS CloudWatch.
@@ -26,7 +25,7 @@ namespace Serilog.Sinks.AwsCloudWatch
 
         /// <summary>
         /// The minimum log event level required in order to write an event to the sink. Defaults
-        /// to <see cref="Information"/>.
+        /// to <see cref="LogEventLevel.Information"/>.
         /// </summary>
         public LogEventLevel MinimumLogEventLevel { get; set; } = DefaultMinimumLogEventLevel;
 

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -1,28 +1,44 @@
 using System;
 using Serilog.Events;
+using static Serilog.Events.LogEventLevel;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
     /// <summary>
-    /// Options that allow configuring the Serilog Sink for AWS CloudWatch 
+    /// Options that allow configuring the Serilog Sink for AWS CloudWatch
     /// </summary>
     public class CloudWatchSinkOptions
     {
         /// <summary>
-        /// The minimum log event level required in order to write an event to the sink. Defaults
-        /// to <see cref="LogEventLevel.Information"/>. 
+        /// The default minimum log event level required in order to write an event to the sink.
         /// </summary>
-        public LogEventLevel MinimumLogEventLevel { get; set; } = LogEventLevel.Information;
+        public const LogEventLevel DefaultMinimumLogEventLevel = Information;
 
         /// <summary>
-        /// The batch size to be used when uploading logs to cloud watch. Defaults to 100.
+        /// The default batch size to be used when uploading logs to AWS CloudWatch.
         /// </summary>
-        public int BatchSizeLimit { get; set; } = 100;
+        public const int DefaultBatchSizeLimit = 100;
+
+        /// <summary>
+        /// The default period to be used when a batch upload should be triggered.
+        /// </summary>
+        public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// The minimum log event level required in order to write an event to the sink. Defaults
+        /// to <see cref="Information"/>.
+        /// </summary>
+        public LogEventLevel MinimumLogEventLevel { get; set; } = DefaultMinimumLogEventLevel;
+
+        /// <summary>
+        /// The batch size to be used when uploading logs to AWS CloudWatch. Defaults to 100.
+        /// </summary>
+        public int BatchSizeLimit { get; set; } = DefaultBatchSizeLimit;
 
         /// <summary>
         /// The period to be used when a batch upload should be triggered. Defaults to 10 seconds.
         /// </summary>
-        public TimeSpan Period { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan Period { get; set; } = DefaultPeriod;
 
         /// <summary>
         /// The log group name to be used in AWS CloudWatch.

--- a/src/Serilog.Sinks.AwsCloudWatch/project.json
+++ b/src/Serilog.Sinks.AwsCloudWatch/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.0",
+    "version": "2.0.0",
     "title": "AWS Cloud Watch Serilog Sink",
     "description": "A Serilog sink that logs to AWS CloudWatch",
     "authors": [

--- a/src/Serilog.Sinks.AwsCloudWatch/project.json
+++ b/src/Serilog.Sinks.AwsCloudWatch/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "title": "AWS Cloud Watch Serilog Sink",
     "description": "A Serilog sink that logs to AWS CloudWatch",
     "authors": [


### PR DESCRIPTION
The library "serilog-settings-configuration" allows Serilog to read
from configuration provided by
"Microsoft.Extensions.Configuration". This integration has particular
limitations, and the existing method `AmazonCloudWatch` cannot be
used.

Three overloads have been created in order to support this:

- One allows the AWS access key, secret access key, and region to be
  read from the environment. Because of this, an implementation of
  `IAmazonCloudWatchLogs` with a default constructor (or a constructor
  with all optional arguments) may be provided via settings. If none
  is provided, an instance of `AmazonCloudWatchLogsClient` is
  created.
- Another takes in the region from settings, and reads the AWS access
  key and secret access key from the environment. This unconditionally
  creates an instance of `AmazonCloudWatchLogsClient`.
- Another takes in all values from settings. This also unconditionally
  creates an instance of `AmazonCloudWatchLogsClient`.

In all cases, the log group name is required, and the log event
renderer, the minimum log event level, the batch size limit, and the
period are optional, with default values. These default values are the
same as those used in `CloudWatchSinkOptions`.
