### PR TITLE
#41 support text formatter

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -5,6 +5,7 @@ using Amazon.Runtime;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
@@ -130,6 +131,126 @@ namespace Serilog.Sinks.AwsCloudWatch
                 BatchSizeLimit = batchSizeLimit,
                 Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer,
+                CreateLogGroup = createLogGroup
+            };
+
+            if (!String.IsNullOrWhiteSpace(logStreamNamePrefix))
+            {
+                options.LogStreamNameProvider = new ConstantLogStreamNameProvider(logStreamNamePrefix);
+            }
+
+            IAmazonCloudWatchLogs client;
+            if (regionName != null)
+            {
+                var region = RegionEndpoint.GetBySystemName(regionName);
+                client = new AmazonCloudWatchLogsClient(region);
+            }
+            else
+            {
+                client = new AmazonCloudWatchLogsClient();
+            }
+            return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="textFormatter">A formatter to format Serilog's LogEvent.</param>
+        /// <param name="accessKey">The access key to use to access AWS CloudWatch.</param>
+        /// <param name="secretAccessKey">The secret access key to use to access AWS CloudWatch.</param>
+        /// <param name="regionName">The system name of the region to which to write.</param>
+        /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accessKey"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="secretAccessKey"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
+            ITextFormatter textFormatter,
+            string accessKey,
+            string secretAccessKey,
+            string regionName = null,
+            string logStreamNamePrefix = null,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
+            TimeSpan? period = null,
+            bool createLogGroup = CloudWatchSinkOptions.DefaultCreateLogGroup)
+        {
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+            if (accessKey == null) { throw new ArgumentNullException(nameof(accessKey)); }
+            if (secretAccessKey == null) { throw new ArgumentNullException(nameof(secretAccessKey)); }
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
+                TextFormatter = textFormatter,
+                CreateLogGroup = createLogGroup
+            };
+
+            if (!String.IsNullOrWhiteSpace(logStreamNamePrefix))
+            {
+                options.LogStreamNameProvider = new ConstantLogStreamNameProvider(logStreamNamePrefix);
+            }
+
+            var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
+            IAmazonCloudWatchLogs client;
+            if (regionName != null)
+            {
+                var region = RegionEndpoint.GetBySystemName(regionName);
+                client = new AmazonCloudWatchLogsClient(credentials, region);
+            }
+            else
+            {
+                client = new AmazonCloudWatchLogsClient(credentials);
+            }
+            return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="textFormatter">A formatter to format Serilog's LogEvent.</param>
+        /// <param name="regionName">The system name of the region to which to write.</param>
+        /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
+            ITextFormatter textFormatter,
+            string regionName = null,
+            string logStreamNamePrefix = null,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
+            TimeSpan? period = null,
+            bool createLogGroup = CloudWatchSinkOptions.DefaultCreateLogGroup)
+        {
+            if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
+                TextFormatter = textFormatter,
                 CreateLogGroup = createLogGroup
             };
 

--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -44,6 +44,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <param name="regionName">The system name of the region to which to write.</param>
         /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
         /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="textFormatter">A formatter to format Serilog's LogEvent instead of using logEventRenderer.</param>
         /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
         /// <param name="period">The period to be used when a batch upload should be triggered.</param>
@@ -59,6 +60,7 @@ namespace Serilog.Sinks.AwsCloudWatch
             string regionName = null,
             string logStreamNamePrefix = null,
             ILogEventRenderer logEventRenderer = null,
+            ITextFormatter textFormatter = null,
             LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
             int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null,
@@ -75,6 +77,7 @@ namespace Serilog.Sinks.AwsCloudWatch
                 BatchSizeLimit = batchSizeLimit,
                 Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer,
+                TextFormatter = textFormatter,
                 CreateLogGroup = createLogGroup
             };
 
@@ -106,6 +109,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <param name="regionName">The system name of the region to which to write.</param>
         /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
         /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="textFormatter">A formatter to format Serilog's LogEvent instead of using logEventRenderer.</param>
         /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
         /// <param name="period">The period to be used when a batch upload should be triggered.</param>
@@ -117,6 +121,7 @@ namespace Serilog.Sinks.AwsCloudWatch
             string regionName = null,
             string logStreamNamePrefix = null,
             ILogEventRenderer logEventRenderer = null,
+            ITextFormatter textFormatter = null,
             LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
             int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null,
@@ -131,125 +136,6 @@ namespace Serilog.Sinks.AwsCloudWatch
                 BatchSizeLimit = batchSizeLimit,
                 Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer,
-                CreateLogGroup = createLogGroup
-            };
-
-            if (!String.IsNullOrWhiteSpace(logStreamNamePrefix))
-            {
-                options.LogStreamNameProvider = new ConstantLogStreamNameProvider(logStreamNamePrefix);
-            }
-
-            IAmazonCloudWatchLogs client;
-            if (regionName != null)
-            {
-                var region = RegionEndpoint.GetBySystemName(regionName);
-                client = new AmazonCloudWatchLogsClient(region);
-            }
-            else
-            {
-                client = new AmazonCloudWatchLogsClient();
-            }
-            return loggerConfiguration.AmazonCloudWatch(options, client);
-        }
-
-        /// <summary>
-        /// Activates logging to AWS CloudWatch
-        /// </summary>
-        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
-        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
-        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
-        /// <param name="textFormatter">A formatter to format Serilog's LogEvent.</param>
-        /// <param name="accessKey">The access key to use to access AWS CloudWatch.</param>
-        /// <param name="secretAccessKey">The secret access key to use to access AWS CloudWatch.</param>
-        /// <param name="regionName">The system name of the region to which to write.</param>
-        /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
-        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
-        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="accessKey"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="secretAccessKey"/> is <see langword="null"/>.</exception>
-        public static LoggerConfiguration AmazonCloudWatch(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string logGroupName,
-            ITextFormatter textFormatter,
-            string accessKey,
-            string secretAccessKey,
-            string regionName = null,
-            string logStreamNamePrefix = null,
-            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
-            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
-            TimeSpan? period = null,
-            bool createLogGroup = CloudWatchSinkOptions.DefaultCreateLogGroup)
-        {
-            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
-            if (accessKey == null) { throw new ArgumentNullException(nameof(accessKey)); }
-            if (secretAccessKey == null) { throw new ArgumentNullException(nameof(secretAccessKey)); }
-
-            var options = new CloudWatchSinkOptions
-            {
-                LogGroupName = logGroupName,
-                MinimumLogEventLevel = minimumLogEventLevel,
-                BatchSizeLimit = batchSizeLimit,
-                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
-                TextFormatter = textFormatter,
-                CreateLogGroup = createLogGroup
-            };
-
-            if (!String.IsNullOrWhiteSpace(logStreamNamePrefix))
-            {
-                options.LogStreamNameProvider = new ConstantLogStreamNameProvider(logStreamNamePrefix);
-            }
-
-            var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
-            IAmazonCloudWatchLogs client;
-            if (regionName != null)
-            {
-                var region = RegionEndpoint.GetBySystemName(regionName);
-                client = new AmazonCloudWatchLogsClient(credentials, region);
-            }
-            else
-            {
-                client = new AmazonCloudWatchLogsClient(credentials);
-            }
-            return loggerConfiguration.AmazonCloudWatch(options, client);
-        }
-
-        /// <summary>
-        /// Activates logging to AWS CloudWatch
-        /// </summary>
-        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
-        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
-        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
-        /// <param name="textFormatter">A formatter to format Serilog's LogEvent.</param>
-        /// <param name="regionName">The system name of the region to which to write.</param>
-        /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
-        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
-        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
-        public static LoggerConfiguration AmazonCloudWatch(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string logGroupName,
-            ITextFormatter textFormatter,
-            string regionName = null,
-            string logStreamNamePrefix = null,
-            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
-            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
-            TimeSpan? period = null,
-            bool createLogGroup = CloudWatchSinkOptions.DefaultCreateLogGroup)
-        {
-            if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
-            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
-
-            var options = new CloudWatchSinkOptions
-            {
-                LogGroupName = logGroupName,
-                MinimumLogEventLevel = minimumLogEventLevel,
-                BatchSizeLimit = batchSizeLimit,
-                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 TextFormatter = textFormatter,
                 CreateLogGroup = createLogGroup
             };

--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -44,7 +44,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <param name="regionName">The system name of the region to which to write.</param>
         /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
         /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
-        /// <param name="textFormatter">A formatter to format Serilog's LogEvent instead of using logEventRenderer.</param>
+        /// <param name="formatter">A formatter to format Serilog's LogEvent instead of using logEventRenderer.</param>
         /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
         /// <param name="period">The period to be used when a batch upload should be triggered.</param>
@@ -60,7 +60,7 @@ namespace Serilog.Sinks.AwsCloudWatch
             string regionName = null,
             string logStreamNamePrefix = null,
             ILogEventRenderer logEventRenderer = null,
-            ITextFormatter textFormatter = null,
+            ITextFormatter formatter = null,
             LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
             int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null,
@@ -77,7 +77,7 @@ namespace Serilog.Sinks.AwsCloudWatch
                 BatchSizeLimit = batchSizeLimit,
                 Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer,
-                TextFormatter = textFormatter,
+                TextFormatter = formatter,
                 CreateLogGroup = createLogGroup
             };
 
@@ -109,7 +109,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <param name="regionName">The system name of the region to which to write.</param>
         /// <param name="logStreamNamePrefix">The log stream name prefix. Will use default log stream name if leave empty.</param>
         /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
-        /// <param name="textFormatter">A formatter to format Serilog's LogEvent instead of using logEventRenderer.</param>
+        /// <param name="formatter">A formatter to format Serilog's LogEvent instead of using logEventRenderer.</param>
         /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
         /// <param name="period">The period to be used when a batch upload should be triggered.</param>
@@ -121,7 +121,7 @@ namespace Serilog.Sinks.AwsCloudWatch
             string regionName = null,
             string logStreamNamePrefix = null,
             ILogEventRenderer logEventRenderer = null,
-            ITextFormatter textFormatter = null,
+            ITextFormatter formatter = null,
             LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
             int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
             TimeSpan? period = null,
@@ -136,7 +136,7 @@ namespace Serilog.Sinks.AwsCloudWatch
                 BatchSizeLimit = batchSizeLimit,
                 Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
                 LogEventRenderer = logEventRenderer,
-                TextFormatter = textFormatter,
+                TextFormatter = formatter,
                 CreateLogGroup = createLogGroup
             };
 

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -69,6 +69,12 @@ namespace Serilog.Sinks.AwsCloudWatch
             }
             this.cloudWatchClient = cloudWatchClient;
             this.options = options;
+
+            if (options.LogEventRenderer != null && options.TextFormatter != null)
+            {
+                throw new System.InvalidOperationException($"{nameof(options.LogEventRenderer)} and {nameof(options.TextFormatter)} cannot both be applied");
+            }
+
             this.renderer = options.LogEventRenderer ?? new RenderedMessageLogEventRenderer();
             this.formatter = options.TextFormatter;
         }
@@ -330,7 +336,6 @@ namespace Serilog.Sinks.AwsCloudWatch
                                 }
                                 else
                                 {
-                                    // Kept for backwards compatability
                                     message = renderer.RenderLogEvent(@event);
                                 }
 

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -1,4 +1,5 @@
 using Serilog.Events;
+using Serilog.Formatting;
 using System;
 
 namespace Serilog.Sinks.AwsCloudWatch
@@ -65,11 +66,14 @@ namespace Serilog.Sinks.AwsCloudWatch
         public ILogStreamNameProvider LogStreamNameProvider { get; set; } = new DefaultLogStreamProvider();
 
         /// <summary>
-        /// A renderer to render Serilog's LogEvent. It defaults to <see cref="RenderedMessageLogEventRenderer"/>,
-        /// which just flattens the log event to a simple string, losing all formatted data.
-        /// It's recommended to implement a custom formatter like a simple JSON formatter with various parameters included.
+        /// OBSOLETE. Use <see cref="TextFormatter"/> instead.  If <see cref="TextFormatter"/> is set then this property will be ignored.
         /// </summary>
         public ILogEventRenderer LogEventRenderer { get; set; }
+
+        /// <summary>
+        /// Formatter used to convert log events to text.
+        /// </summary>
+        public ITextFormatter TextFormatter { get; set; }
 
         /// <summary>
         /// The number of attempts to retry in the case of a failure.

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -66,12 +66,16 @@ namespace Serilog.Sinks.AwsCloudWatch
         public ILogStreamNameProvider LogStreamNameProvider { get; set; } = new DefaultLogStreamProvider();
 
         /// <summary>
-        /// OBSOLETE. Use <see cref="TextFormatter"/> instead.  If <see cref="TextFormatter"/> is set then this property will be ignored.
+        /// A renderer to render Serilog's LogEvent. It defaults to <see cref="RenderedMessageLogEventRenderer"/>,
+        /// which just flattens the log event to a simple string, losing all formatted data.
+        /// It's recommended to implement a custom formatter like a simple JSON formatter with various parameters included.
+        /// If <see cref="TextFormatter"/> and <see cref="LogEventRenderer"/> are both set then an <see cref="InvalidOperationException"/> will be thrown.
         /// </summary>
         public ILogEventRenderer LogEventRenderer { get; set; }
 
         /// <summary>
-        /// Formatter used to convert log events to text.
+        /// Standard Serilog formatter to convert log events to text instead of the AwsCloudWatch specific <see cref="LogEventRenderer"/>.
+        /// If <see cref="TextFormatter"/> and <see cref="LogEventRenderer"/> are both set then an <see cref="InvalidOperationException"/> will be thrown.
         /// </summary>
         public ITextFormatter TextFormatter { get; set; }
 

--- a/src/Serilog.Sinks.AwsCloudWatch/TextFormatterLogEventRenderer.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/TextFormatterLogEventRenderer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.AwsCloudWatch
+{
+    /// <summary>
+    /// An <see cref="ILogEventRenderer"/> that wraps a Serilog <see cref="ITextFormatter"/> and uses it to format the log output
+    /// </summary>
+    public class TextFormatterLogEventRenderer : ILogEventRenderer
+    {
+        private readonly ITextFormatter textFormatter;
+
+        public TextFormatterLogEventRenderer(ITextFormatter textFormatter)
+        {
+            this.textFormatter = textFormatter ?? throw new ArgumentNullException(nameof(textFormatter));
+        }
+
+        public string RenderLogEvent(LogEvent logEvent)
+        {
+            using (var writer = new StringWriter())
+            {
+                this.textFormatter.Format(logEvent, writer);
+                writer.Flush();
+                return writer.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Following from this issue: https://github.com/Cimpress-MCP/serilog-sinks-awscloudwatch/issues/41 and the resultant PR that was abandoned.

This changeset is designed to have zero impact on existing users, but switch to using the text formatter instead of log event renderer if provided. 

The usage of text formatter/naming conventions/summary texts chosen to match the File sink.
  