### PR TITLE
Adding new functionality to support a dynamic log group name 

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -23,7 +23,8 @@ namespace Serilog.Sinks.AwsCloudWatch
             // validating input parameters
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (options == null) throw new ArgumentNullException(nameof(options));
-            if (string.IsNullOrEmpty(options.LogGroupName)) throw new ArgumentException("options.LogGroupName");
+            if (string.IsNullOrEmpty(options.LogGroupName) && !options.LogEventBasedLogGroupName) throw new ArgumentException("options.LogGroupName");
+            if(options.LogEventBasedLogGroupName && string.IsNullOrEmpty(options.LogGroupPropertyKey)) throw new ArgumentException(nameof(options.LogGroupPropertyKey));
             if (cloudWatchClient == null) throw new ArgumentNullException(nameof(cloudWatchClient));
 
             // create the sink

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -61,6 +61,11 @@ namespace Serilog.Sinks.AwsCloudWatch
         public string LogGroupName { get; set; }
 
         /// <summary>
+        /// The respective LogEvent property associated to the groupName value.
+        /// </summary>
+        public string LogGroupPropertyKey { get; set; }
+
+        /// <summary>
         /// The log stream name to be used in AWS CloudWatch.
         /// </summary>
         public ILogStreamNameProvider LogStreamNameProvider { get; set; } = new DefaultLogStreamProvider();
@@ -83,5 +88,15 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// The number of attempts to retry in the case of a failure.
         /// </summary>
         public byte RetryAttempts { get; set; } = DefaultRetryAttempts;
+
+        /// <summary>
+        /// Consider using some incoming event log information to build the log group name.
+        /// </summary>
+        public bool LogEventBasedLogGroupName { get; set; } = DefaultLogEventBasedLogGroupName;
+
+        /// <summary>
+        /// Default value for LogEventBasedLogGroupName.
+        /// </summary>
+        public const bool DefaultLogEventBasedLogGroupName = false;
     }
 }


### PR DESCRIPTION
I altered a few things in the sink itself and in the options class to provide me a feature to create the log group dynamically. The point here is to create the log group based on log event's parameterized property. In my case, I have a single web api responsible for doing all the logging of the entire system (I have a micro-services architecture here and all of the services send it's logs through a RabbitMQ exchange, that is consumed by this single logging API).

With this new functionality, I can organize all of the logs in a good way at AWS CloudWatch.