### PR TITLE
Adding InstanceIdLogStreamNameProvider to use the machine instance id

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/LogStreamNameProvider/InstanceIdLogStreamNameProvider.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/LogStreamNameProvider/InstanceIdLogStreamNameProvider.cs
@@ -1,0 +1,17 @@
+﻿namespace Serilog.Sinks.AwsCloudWatch.LogStreamNameProvider
+{
+	public class InstanceIdLogStreamNameProvider : ILogStreamNameProvider
+	{
+		private readonly string _instanceId;
+
+		public InstanceIdLogStreamNameProvider()
+		{
+			_instanceId = Amazon.Util.EC2InstanceMetadata.InstanceId;
+		}
+
+		public string GetLogStreamName()
+		{
+			return _instanceId;
+		}
+	}
+}


### PR DESCRIPTION
Adding InstanceIdLogStreamNameProvider to use the machine instance id as the stream name.

Connects #59 