### PR TITLE
Downgrade .NET to 4.5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Serilog Sink for AWS CloudWatch
 
-This Serilog Sink allows to log to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). It supports .NET Framework 4.6 and .NET Core.
+This Serilog Sink allows to log to [AWS CloudWatch](https://aws.amazon.com/cloudwatch/). It supports .NET Framework 4.5 and .NET Core.
 
 ## Version and build status
 

--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>AWS Cloud Watch Serilog Sink</AssemblyTitle>
     <Version>0.0.1</Version>
     <Authors>Markus Thurner</Authors>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.AwsCloudWatch</AssemblyName>
     <PackageId>Serilog.Sinks.AwsCloudWatch</PackageId>
     <PackageTags>serilog;logging;dnx;coreclr;AWS;CloudWatch</PackageTags>
@@ -29,5 +29,5 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
We have a compatibility requirement to use .NET 4.5 and so are unable to use this library with it targeting .NET 4.5.1

This PR is to downgrade the required .NET version to 4.5, as I couldn't see any requirement to use .NET 4.5.1 exclusively.