### PR TITLE
Add configuration extension for setting ILogStreamNameProvider by type

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -39,6 +39,103 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
         /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
         /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="logStreamNameProvider">The log stream name provider.</param>
+        /// <param name="accessKey">The access key to use to access AWS CloudWatch.</param>
+        /// <param name="secretAccessKey">The secret access key to use to access AWS CloudWatch.</param>
+        /// <param name="regionName">The system name of the region to which to write.</param>
+        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accessKey"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="secretAccessKey"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logStreamNameProvider"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
+            ILogStreamNameProvider logStreamNameProvider,
+            string accessKey,
+            string secretAccessKey,
+            string regionName = null,
+            ILogEventRenderer logEventRenderer = null,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
+            TimeSpan? period = null,
+            bool createLogGroup = CloudWatchSinkOptions.DefaultCreateLogGroup)
+        {
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+            if (logStreamNameProvider == null) { throw new ArgumentNullException(nameof(logStreamNameProvider)); }
+            if (accessKey == null) { throw new ArgumentNullException(nameof(accessKey)); }
+            if (secretAccessKey == null) { throw new ArgumentNullException(nameof(secretAccessKey)); }
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
+                LogStreamNameProvider = logStreamNameProvider,
+                LogEventRenderer = logEventRenderer,
+                CreateLogGroup = createLogGroup
+            };
+
+            var credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
+            var client = CreateClient(credentials, regionName);
+            return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
+        /// <param name="logStreamNameProvider">The log stream name provider.</param>
+        /// <param name="regionName">The system name of the region to which to write.</param>
+        /// <param name="logEventRenderer">A renderer to render Serilog's LogEvent.</param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchSizeLimit">The batch size to be used when uploading logs to AWS CloudWatch.</param>
+        /// <param name="period">The period to be used when a batch upload should be triggered.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="logGroupName"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="logStreamNameProvider"/> is <see langword="null"/>.</exception>
+        public static LoggerConfiguration AmazonCloudWatch(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string logGroupName,
+            ILogStreamNameProvider logStreamNameProvider,
+            string regionName = null,
+            ILogEventRenderer logEventRenderer = null,
+            LogEventLevel minimumLogEventLevel = CloudWatchSinkOptions.DefaultMinimumLogEventLevel,
+            int batchSizeLimit = CloudWatchSinkOptions.DefaultBatchSizeLimit,
+            TimeSpan? period = null,
+            bool createLogGroup = CloudWatchSinkOptions.DefaultCreateLogGroup)
+        {
+            if (logGroupName == null) throw new ArgumentNullException(nameof(logGroupName));
+            if (logStreamNameProvider == null) { throw new ArgumentNullException(nameof(logStreamNameProvider)); }
+
+            var options = new CloudWatchSinkOptions
+            {
+                LogGroupName = logGroupName,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                BatchSizeLimit = batchSizeLimit,
+                Period = period ?? CloudWatchSinkOptions.DefaultPeriod,
+                LogStreamNameProvider = logStreamNameProvider,
+                LogEventRenderer = logEventRenderer,
+                CreateLogGroup = createLogGroup
+            };
+
+            var client = CreateClient(regionName);
+            return loggerConfiguration.AmazonCloudWatch(options, client);
+        }
+
+        /// <summary>
+        /// Activates logging to AWS CloudWatch
+        /// </summary>
+        /// <remarks>This overload is intended to be used via AppSettings integration.</remarks>
+        /// <param name="loggerConfiguration">The LoggerSinkConfiguration to register this sink with.</param>
+        /// <param name="logGroupName">The log group name to be used in AWS CloudWatch.</param>
         /// <param name="accessKey">The access key to use to access AWS CloudWatch.</param>
         /// <param name="secretAccessKey">The secret access key to use to access AWS CloudWatch.</param>
         /// <param name="regionName">The system name of the region to which to write.</param>


### PR DESCRIPTION
I want to set a custom ILogStreamNameProvider, but I want to control my Serilog configuration entirely via config file.

This change adds the ability to configure the sink like this (using Serilog.Sinks.Configuration with a JSON configuration file):

```json
"Serilog": {
 "WriteTo": [
   {
     "Name": "AmazonCloudWatch",
     "Args": {
       "logGroupName": "my-log-group-name",
       "logEventRenderer": "GreatStuff.MyLogEventRenderer, MyAssembly",
       "logStreamNameProvider": "GreatStuff.MyLogStreamNameProvider, MyAssembly",
       "regionName": "us-east-1"
     }
   }
 ]
}
```

I tested this change in my project and it creates a sink with `LogStreamNameProvider` set to a new instance of `MyLogStreamNameProvider`.