### PR TITLE
Added log group retention

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -121,6 +121,12 @@ namespace Serilog.Sinks.AwsCloudWatch
                 {
                     CreateLogGroupRequest createRequest = new CreateLogGroupRequest(options.LogGroupName);
                     var createResponse = await cloudWatchClient.CreateLogGroupAsync(createRequest);
+
+                    if (options.LogGroupRetention.HasValue)
+                    {
+                        PutRetentionPolicyRequest putRetentionRequest = new PutRetentionPolicyRequest(options.LogGroupName, options.LogGroupRetention.Value.Days);
+                        await cloudWatchClient.PutRetentionPolicyAsync(putRetentionRequest);
+                    }
                 }
             }
         }

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -51,6 +51,11 @@ namespace Serilog.Sinks.AwsCloudWatch
         public TimeSpan Period { get; set; } = DefaultPeriod;
 
         /// <summary>
+        /// The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.
+        /// </summary>
+        public TimeSpan? LogGroupRetention { get; set; }
+
+        /// <summary>
         /// The log group name to be used in AWS CloudWatch.
         /// </summary>
         public bool CreateLogGroup { get; set; } = DefaultCreateLogGroup;

--- a/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
@@ -26,6 +26,11 @@ namespace Serilog.Sinks.AwsCloudWatch
         TimeSpan Period { get; }
 
         /// <summary>
+        /// The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.
+        /// </summary>
+        TimeSpan? LogGroupRetention { get; set; }
+
+        /// <summary>
         /// The log group name to be used in AWS CloudWatch.
         /// </summary>
         bool CreateLogGroup { get; }


### PR DESCRIPTION
The author of #33 never responded to feedback so I picked this up and incorporated the original feedback.

**Use Case**

My team is starting to use AWS more and so Cloud Watch logging is a natural progression.  We're letting our application create the log groups, but we don't want the default value of no expiration.  To avoid manually having to change this in the AWS Console for each environment of our application, I'd like to make it configuration as part of the logger.

**Questions**

1. As the [documentation](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html) shows there are specific values allowed for the retention (in days).  An `enum` might be a better fit instead of a `TimeSpan` to force people into using a valid value (otherwise a `Amazon.CloudWatchLogs.Model.InvalidParameterException` exception will be thrown)
2. Do you want to support retention policy changes?  As an example, say the log group is originally created with a retention policy of 1 day.  Next week, someone changes the options to use the same log group, but with a retention policy of 3 days.  Should we update the policy or do we want to assume this can only be defined during log group creation?