### PR TITLE
CloudWatchLogSink Causes OutOfMemory Errors by Defaulting to an Unbounded Queue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ The preferred approach for configuration is to construct the necessary objects v
     // other defaults defaults
     MinimumLogEventLevel = LogEventLevel.Information,
     BatchSizeLimit = 100,
+    QueueSizeLimit = 10000,
     Period = TimeSpan.FromSeconds(10),
     CreateLogGroup = true,
     LogStreamNameProvider = new DefaultLogStreamProvider(),

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -62,7 +62,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// </summary>
         /// <param name="cloudWatchClient">The cloud watch client.</param>
         /// <param name="options">The options.</param>
-        public CloudWatchLogSink(IAmazonCloudWatchLogs cloudWatchClient, ICloudWatchSinkOptions options): base(options.BatchSizeLimit, options.Period)
+        public CloudWatchLogSink(IAmazonCloudWatchLogs cloudWatchClient, ICloudWatchSinkOptions options): base(options.BatchSizeLimit, options.Period, options.QueueSizeLimit)
         {
             if (string.IsNullOrEmpty(options?.LogGroupName))
             {

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -20,6 +20,14 @@ namespace Serilog.Sinks.AwsCloudWatch
         public const int DefaultBatchSizeLimit = 100;
 
         /// <summary>
+        /// The default qeueue size to be used creating the queue used to hold batched log events.
+        /// Defaults to a very large number to retain backwards compatibitliy for old clients who
+        /// relied on unbounded queue sizes while still providing safe runtime behavior.
+        /// It is recommended to tune this queue size along with batchSize for your application logging use cases.
+        /// </summary>
+        public const int DefaultQueueSizeLimit = 10000;
+
+        /// <summary>
         /// The default to be used when deciding to create the log group or not
         /// </summary>
         public const bool DefaultCreateLogGroup = true;
@@ -44,6 +52,11 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// The batch size to be used when uploading logs to AWS CloudWatch. Defaults to 100.
         /// </summary>
         public int BatchSizeLimit { get; set; } = DefaultBatchSizeLimit;
+
+        /// <summary>
+        /// The queue size to be used when holding batched log events in memory. Defaults to 10000.
+        /// </summary>
+        public int QueueSizeLimit { get; set; } = DefaultQueueSizeLimit;
 
         /// <summary>
         /// The period to be used when a batch upload should be triggered. Defaults to 10 seconds.

--- a/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
@@ -21,6 +21,11 @@ namespace Serilog.Sinks.AwsCloudWatch
         int BatchSizeLimit { get; }
 
         /// <summary>
+        /// The queue size to be used when holding batched log events in memory. Defaults to 10000.
+        /// </summary>
+        int QueueSizeLimit { get; }
+
+        /// <summary>
         /// The period to be used when a batch upload should be triggered. Defaults to 10 seconds.
         /// </summary>
         TimeSpan Period { get; }


### PR DESCRIPTION
The `CloudWatchLogSink` does not call the 3-arg ctor for `PeriodicBatchingSink` and thus defaults to an unbounded internal queue.  When there are network issues that prevent the Sink from flushing the queue, log events will collect in memory and eventually cause OutOfMemory errors to pop up in other areas of the production application code.  

This PR seeks to accomplish a few things:
* `QueueSize` should be configurable through `app.config` to allow clients to tune the queue size for their use cases
* The default `QueueSize` should be relatively high for clients which haven't thought about logging batch queue sizes yet still be small enough not to cause memory problems
* A `QueueSize` of `-1`  should be strongly discouraged yet is still allowed to flow and will still allow an unbounded queue

We recommend clients who need guaranteed delivery of log events to choose a different method of ingesting logs into CloudWatch, notably the AWS CloudWatch Agent, by logging directly to the file system and ingesting to AWS CloudWatch using another process.

This PR is the result of a 3 month investigation of intermittent outages at our client sites which we now know (from `procdumps`) is due to many gigabytes of log events collecting in the `PeriodicBatchingSink` `queue`
https://github.com/serilog/serilog-sinks-periodicbatching/blob/dev/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs#L18

Let me know if this works for you.

Thanks!