### PR TITLE
Removed property that is no longer on the interface

### DIFF
--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
@@ -961,11 +961,6 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
             {
                 return "NonUniqueName";
             }
-
-            public bool IsUniqueName()
-            {
-                return false;
-            }
         }
     }
 }


### PR DESCRIPTION
Removed from a test implementation a property that is no longer on the ILogStreamNameProvider interface.