### PR TITLE
Fix describe next sequence token

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -168,6 +168,10 @@ namespace Serilog.Sinks.AwsCloudWatch
                 };
                 var createLogStreamResponse = await cloudWatchClient.CreateLogStreamAsync(createLogStreamRequest);
             }
+            else
+            {
+                nextSequenceToken = logStream.UploadSequenceToken;
+            }
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -296,6 +296,8 @@ namespace Serilog.Sinks.AwsCloudWatch
                     try
                     {
                         await UpdateLogStreamSequenceTokenAsync();
+
+                        putLogEventsRequest.SequenceToken = nextSequenceToken;
                     }
                     catch (Exception ex)
                     {
@@ -314,6 +316,8 @@ namespace Serilog.Sinks.AwsCloudWatch
                     try
                     {
                         await UpdateLogStreamSequenceTokenAsync();
+
+                        putLogEventsRequest.SequenceToken = nextSequenceToken;
                     }
                     catch (Exception ex)
                     {

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -112,9 +112,17 @@ namespace Serilog.Sinks.AwsCloudWatch
             if (options.CreateLogGroup)
             {
                 // see if the log group already exists
-                var describeRequest = new DescribeLogGroupsRequest { LogGroupNamePrefix = options.LogGroupName, Limit = 1 };
-                var logGroups = await cloudWatchClient.DescribeLogGroupsAsync(describeRequest);
-                var logGroup = logGroups.LogGroups.FirstOrDefault(lg => string.Equals(lg.LogGroupName, options.LogGroupName, StringComparison.OrdinalIgnoreCase));
+                var describeRequest = new DescribeLogGroupsRequest
+                {
+                    LogGroupNamePrefix = options.LogGroupName
+                };
+
+                var logGroups = await cloudWatchClient
+                    .DescribeLogGroupsAsync(describeRequest);
+
+                var logGroup = logGroups
+                    .LogGroups
+                    .FirstOrDefault(lg => string.Equals(lg.LogGroupName, options.LogGroupName, StringComparison.Ordinal));
 
                 // create log group if it doesn't exist
                 if (logGroup == null)
@@ -148,9 +156,18 @@ namespace Serilog.Sinks.AwsCloudWatch
         private async Task CreateLogStreamAsync()
         {
             // see if the log stream already exists
-            var describeLogStreamsRequest = new DescribeLogStreamsRequest { LogGroupName = options.LogGroupName, LogStreamNamePrefix = logStreamName, Limit = 1 };
-            var describeLogStreamsResponse = await cloudWatchClient.DescribeLogStreamsAsync(describeLogStreamsRequest);
-            var logStream = describeLogStreamsResponse.LogStreams.FirstOrDefault(ls => string.Equals(ls.LogStreamName, logStreamName, StringComparison.OrdinalIgnoreCase));
+            var describeLogStreamsRequest = new DescribeLogStreamsRequest
+            {
+                LogGroupName = options.LogGroupName,
+                LogStreamNamePrefix = logStreamName
+            };
+
+            var describeLogStreamsResponse = await cloudWatchClient
+                .DescribeLogStreamsAsync(describeLogStreamsRequest);
+
+            var logStream = describeLogStreamsResponse
+                .LogStreams
+                .SingleOrDefault(ls => string.Equals(ls.LogStreamName, logStreamName, StringComparison.Ordinal));
 
             // create log stream if it doesn't exist
             if (logStream == null)

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -255,21 +255,21 @@ namespace Serilog.Sinks.AwsCloudWatch
                 return;
             }
 
-            // creates the request to upload a new event to CloudWatch
-            var putLogEventsRequest = new PutLogEventsRequest
-            {
-                LogGroupName = options.LogGroupName,
-                LogStreamName = logStreamName,
-                SequenceToken = nextSequenceToken,
-                LogEvents = batch
-            };
-
             var success = false;
             var attemptIndex = 0;
             while (!success && attemptIndex <= options.RetryAttempts)
             {
                 try
                 {
+                    // creates the request to upload a new event to CloudWatch
+                    var putLogEventsRequest = new PutLogEventsRequest
+                    {
+                        LogGroupName = options.LogGroupName,
+                        LogStreamName = logStreamName,
+                        SequenceToken = nextSequenceToken,
+                        LogEvents = batch
+                    };
+
                     // actually upload the event to CloudWatch
                     var putLogEventsResponse = await cloudWatchClient.PutLogEventsAsync(putLogEventsRequest);
 
@@ -300,8 +300,6 @@ namespace Serilog.Sinks.AwsCloudWatch
                     try
                     {
                         await UpdateLogStreamSequenceTokenAsync();
-
-                        putLogEventsRequest.SequenceToken = nextSequenceToken;
                     }
                     catch (Exception ex)
                     {
@@ -310,7 +308,6 @@ namespace Serilog.Sinks.AwsCloudWatch
                         // try again with a different log stream
                         UpdateLogStreamName();
                         await CreateLogStreamAsync();
-                        putLogEventsRequest.LogStreamName = logStreamName;
                     }
                     attemptIndex++;
                 }
@@ -320,8 +317,6 @@ namespace Serilog.Sinks.AwsCloudWatch
                     try
                     {
                         await UpdateLogStreamSequenceTokenAsync();
-
-                        putLogEventsRequest.SequenceToken = nextSequenceToken;
                     }
                     catch (Exception ex)
                     {
@@ -330,7 +325,6 @@ namespace Serilog.Sinks.AwsCloudWatch
                         // try again with a different log stream
                         UpdateLogStreamName();
                         await CreateLogStreamAsync();
-                        putLogEventsRequest.LogStreamName = logStreamName;
                     }
                     attemptIndex++;
                 }

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -112,20 +112,20 @@ namespace Serilog.Sinks.AwsCloudWatch
             if (options.CreateLogGroup)
             {
                 // see if the log group already exists
-                DescribeLogGroupsRequest describeRequest = new DescribeLogGroupsRequest { LogGroupNamePrefix = options.LogGroupName, Limit = 1 };
+                var describeRequest = new DescribeLogGroupsRequest { LogGroupNamePrefix = options.LogGroupName, Limit = 1 };
                 var logGroups = await cloudWatchClient.DescribeLogGroupsAsync(describeRequest);
                 var logGroup = logGroups.LogGroups.FirstOrDefault(lg => string.Equals(lg.LogGroupName, options.LogGroupName, StringComparison.OrdinalIgnoreCase));
 
                 // create log group if it doesn't exist
                 if (logGroup == null)
                 {
-                    CreateLogGroupRequest createRequest = new CreateLogGroupRequest(options.LogGroupName);
+                    var createRequest = new CreateLogGroupRequest(options.LogGroupName);
                     var createResponse = await cloudWatchClient.CreateLogGroupAsync(createRequest);
 
                     // update the retention policy if a specific period is defined
                     if (options.LogGroupRetentionPolicy != LogGroupRetentionPolicy.Indefinitely)
                     {
-                        PutRetentionPolicyRequest putRetentionRequest = new PutRetentionPolicyRequest(options.LogGroupName, (int)options.LogGroupRetentionPolicy);
+                        var putRetentionRequest = new PutRetentionPolicyRequest(options.LogGroupName, (int)options.LogGroupRetentionPolicy);
                         await cloudWatchClient.PutRetentionPolicyAsync(putRetentionRequest);
                     }
                 }
@@ -148,14 +148,14 @@ namespace Serilog.Sinks.AwsCloudWatch
         private async Task CreateLogStreamAsync()
         {
             // see if the log stream already exists
-            DescribeLogStreamsRequest describeLogStreamsRequest = new DescribeLogStreamsRequest { LogGroupName = options.LogGroupName, LogStreamNamePrefix = logStreamName, Limit = 1 };
+            var describeLogStreamsRequest = new DescribeLogStreamsRequest { LogGroupName = options.LogGroupName, LogStreamNamePrefix = logStreamName, Limit = 1 };
             var describeLogStreamsResponse = await cloudWatchClient.DescribeLogStreamsAsync(describeLogStreamsRequest);
             var logStream = describeLogStreamsResponse.LogStreams.FirstOrDefault(ls => string.Equals(ls.LogStreamName, logStreamName, StringComparison.OrdinalIgnoreCase));
 
             // create log stream if it doesn't exist
             if (logStream == null)
             {
-                CreateLogStreamRequest createLogStreamRequest = new CreateLogStreamRequest
+                var createLogStreamRequest = new CreateLogStreamRequest
                 {
                     LogGroupName = options.LogGroupName,
                     LogStreamName = logStreamName
@@ -170,7 +170,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <exception cref="Serilog.Sinks.AwsCloudWatch.AwsCloudWatchSinkException"></exception>
         private async Task UpdateLogStreamSequenceTokenAsync()
         {
-            DescribeLogStreamsRequest describeLogStreamsRequest = new DescribeLogStreamsRequest
+            var describeLogStreamsRequest = new DescribeLogStreamsRequest
             {
                 LogGroupName = options.LogGroupName,
                 LogStreamNamePrefix = logStreamName
@@ -231,7 +231,7 @@ namespace Serilog.Sinks.AwsCloudWatch
             }
 
             // creates the request to upload a new event to CloudWatch
-            PutLogEventsRequest putLogEventsRequest = new PutLogEventsRequest
+            var putLogEventsRequest = new PutLogEventsRequest
             {
                 LogGroupName = options.LogGroupName,
                 LogStreamName = logStreamName,


### PR DESCRIPTION
Please see individual commits. The next sequence token was never appropriately applied during failure scenarios or when a stream already existed.