### PR TITLE
Properly truncating messages with non ASCII characters (>1 byte) in it

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -379,8 +379,8 @@ namespace Serilog.Sinks.AwsCloudWatch
                                         sb.CopyTo(0, message, 0, message.Length);
                                     }
 
-                                    var messageLength = System.Text.Encoding.UTF8.GetByteCount(message);
-                                    if (messageLength > MaxLogEventSize)
+                                    var messageLength = message.Length;
+                                    if (System.Text.Encoding.UTF8.GetByteCount(message) > MaxLogEventSize)
                                     {
                                         // truncate event message
                                         Debugging.SelfLog.WriteLine("Truncating log event with length of {0}", messageLength);

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -43,6 +43,11 @@ namespace Serilog.Sinks.AwsCloudWatch
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(10);
 
         /// <summary>
+        /// The default to be used when truncating long messages that exceeds CloudWatch limit.
+        /// </summary>
+        public const bool DefaultUnicodeAwareTruncate = false;
+
+        /// <summary>
         /// The minimum log event level required in order to write an event to the sink. Defaults
         /// to <see cref="LogEventLevel.Information"/>.
         /// </summary>
@@ -93,5 +98,10 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// The number of attempts to retry in the case of a failure.
         /// </summary>
         public byte RetryAttempts { get; set; } = DefaultRetryAttempts;
+
+        /// <summary>
+        /// Whether unicode awareness needs to be used when truncating long messages that exceeds CloudWatch limit.
+        /// </summary>
+        public bool UnicodeAwareTruncate { get; set; } = DefaultUnicodeAwareTruncate;
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
@@ -60,5 +60,10 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// The number of attempts to retry in the case of a failure.
         /// </summary>
         byte RetryAttempts { get; }
+
+        /// <summary>
+        /// Whether unicode awareness needs to be used when truncating long messages that exceeds CloudWatch limit.
+        /// </summary>
+        bool UnicodeAwareTruncate { get; set; }
     }
 }

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
@@ -337,7 +337,7 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
             var client = new Mock<IAmazonCloudWatchLogs>(MockBehavior.Strict);
             var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
             textFormatterMock.Setup(s => s.Format(It.IsAny<LogEvent>(), It.IsAny<TextWriter>())).Callback((LogEvent l, TextWriter t) => l.RenderMessage(t));
-            var options = new CloudWatchSinkOptions { TextFormatter = textFormatterMock.Object, LogGroupName = "Test-Log-Group-Name" };
+            var options = new CloudWatchSinkOptions { TextFormatter = textFormatterMock.Object, LogGroupName = "Test-Log-Group-Name", UnicodeAwareTruncate = true };
             var sink = new CloudWatchLogSink(client.Object, options);
             var largeEventMessage = CreateMessage(CloudWatchLogSink.MaxLogEventSize + 1, NonASCIIAlphabet);
             var events = new LogEvent[]


### PR DESCRIPTION
There's an issue with longer messages that contain non ASCII characters. Current implementation trims them based on character count which works for ASCII (1-byte) characters but fails if string contains characters that occupy more than 1 byte. It leads to an Exception when publishing batch and terminating EmitBatchAsync due to exception that also creates a large queue of pending events if they are received withing short amount of time sometimes leading to OutOfMemory exceptions. This PR solves this issue by properly truncating message using byte count.