### PR TITLE
Properly truncating messages with multi-byte characters

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -379,8 +379,8 @@ namespace Serilog.Sinks.AwsCloudWatch
                                         sb.CopyTo(0, message, 0, message.Length);
                                     }
 
-                                    var messageLength = System.Text.Encoding.UTF8.GetByteCount(message);
-                                    if (messageLength > MaxLogEventSize)
+                                    var messageLength = message.Length;
+                                    if (System.Text.Encoding.UTF8.GetByteCount(message) > MaxLogEventSize)
                                     {
                                         // truncate event message
                                         Debugging.SelfLog.WriteLine("Truncating log event with length of {0}", messageLength);

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -43,6 +43,11 @@ namespace Serilog.Sinks.AwsCloudWatch
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(10);
 
         /// <summary>
+        /// The default to be used when truncating long messages that exceeds CloudWatch limit.
+        /// </summary>
+        public const bool DefaultUnicodeAwareTruncate = false;
+
+        /// <summary>
         /// The minimum log event level required in order to write an event to the sink. Defaults
         /// to <see cref="LogEventLevel.Information"/>.
         /// </summary>
@@ -93,5 +98,10 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// The number of attempts to retry in the case of a failure.
         /// </summary>
         public byte RetryAttempts { get; set; } = DefaultRetryAttempts;
+
+        /// <summary>
+        /// Whether unicode awareness needs to be used when truncating long messages that exceeds CloudWatch limit.
+        /// </summary>
+        public bool UnicodeAwareTruncate { get; set; } = DefaultUnicodeAwareTruncate;
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -1,5 +1,6 @@
 using Serilog.Events;
 using Serilog.Formatting;
+using Serilog.Sinks.AwsCloudWatch.EventTransformer;
 using System;
 
 namespace Serilog.Sinks.AwsCloudWatch
@@ -100,8 +101,8 @@ namespace Serilog.Sinks.AwsCloudWatch
         public byte RetryAttempts { get; set; } = DefaultRetryAttempts;
 
         /// <summary>
-        /// Whether unicode awareness needs to be used when truncating long messages that exceeds CloudWatch limit.
+        /// Event Transformer handling transformation of Serilog event to CloudWatch one.
         /// </summary>
-        public bool UnicodeAwareTruncate { get; set; } = DefaultUnicodeAwareTruncate;
+        public IEventTransformer EventTransformer { get; set; } = new DefaultEventTransformer();
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchSinkOptions.cs
@@ -44,11 +44,6 @@ namespace Serilog.Sinks.AwsCloudWatch
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        /// The default to be used when truncating long messages that exceeds CloudWatch limit.
-        /// </summary>
-        public const bool DefaultUnicodeAwareTruncate = false;
-
-        /// <summary>
         /// The minimum log event level required in order to write an event to the sink. Defaults
         /// to <see cref="LogEventLevel.Information"/>.
         /// </summary>

--- a/src/Serilog.Sinks.AwsCloudWatch/EventTransformer/DefaultEventTransformer.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/EventTransformer/DefaultEventTransformer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Amazon.CloudWatchLogs.Model;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.AwsCloudWatch.EventTransformer
+{
+    /// <summary>
+    /// Default implementation of IEventTransformer, generates Cloudwatch object and handles maximum Cloudwatch event size truncating message if needed.
+    /// Does not handle truncating properly if multi-byte characters are present (UTF-8) - if this is your case, use <see cref="UnicodeEventTransformer"/> instead.
+    /// </summary>
+    public class DefaultEventTransformer : IEventTransformer
+    {
+        /// <summary>
+        /// Performs message transformation and truncation.
+        /// </summary>
+        /// <param name="textFormatter">TextFormatter to be used</param>
+        /// <param name="event">Serilog event</param>
+        /// <returns>Cloudwatch event object</returns>
+        public InputLogEvent TransformEvent(ITextFormatter textFormatter, LogEvent @event)
+        {
+            string message = null;
+            using (var writer = new StringWriter())
+            {
+                textFormatter.Format(@event, writer);
+                writer.Flush();
+                message = writer.ToString();
+            }
+            var messageLength = System.Text.Encoding.UTF8.GetByteCount(message);
+            if (messageLength > CloudWatchLogSink.MaxLogEventSize)
+            {
+                // truncate event message
+                Debugging.SelfLog.WriteLine("Truncating log event with length of {0}", messageLength);
+                message = message.Substring(0, CloudWatchLogSink.MaxLogEventSize);
+            }
+            return new InputLogEvent
+            {
+                Message = message,
+                Timestamp = @event.Timestamp.UtcDateTime
+            };
+
+        }
+    }
+}

--- a/src/Serilog.Sinks.AwsCloudWatch/EventTransformer/IEventTransformer.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/EventTransformer/IEventTransformer.cs
@@ -1,0 +1,23 @@
+﻿using Amazon.CloudWatchLogs.Model;
+using Serilog.Events;
+using Serilog.Formatting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Serilog.Sinks.AwsCloudWatch.EventTransformer
+{
+    /// <summary>
+    /// Interface handling transformation of Serilog event into CloudWatch one.
+    /// </summary>
+    public interface IEventTransformer
+    {
+        /// <summary>
+        /// Transforms Serilog event object into CloudWatch event object.
+        /// </summary>
+        /// <param name="textFormatter">Serilog TextFormatter to be used</param>
+        /// <param name="event">Serilog event to be transformed</param>
+        /// <returns>CloudWatch event object</returns>
+        InputLogEvent TransformEvent(ITextFormatter textFormatter, LogEvent @event);
+    }
+}

--- a/src/Serilog.Sinks.AwsCloudWatch/EventTransformer/UnicodeEventTransformer.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/EventTransformer/UnicodeEventTransformer.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Amazon.CloudWatchLogs.Model;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.AwsCloudWatch.EventTransformer
+{
+    /// <summary>
+    /// Default implementation of IEventTransformer, generates Cloudwatch object and handles maximum Cloudwatch event size truncating message if needed.
+    /// Poperly handles truncating of multi-byte characters (UTF-8) at the small performance cost. Use <see cref="DefaultEventTransformer"/> if you're 
+    /// confident that your message will only consist of ASCII characters or it will never exceeds maximum length.
+    /// </summary>
+    public class UnicodeEventTransformer : IEventTransformer
+    {
+        /// <summary>
+        /// Performs message transformation and multibyte-aware truncation.
+        /// </summary>
+        /// <param name="textFormatter">TextFormatter to be used</param>
+        /// <param name="event">Serilog event</param>
+        /// <returns>Cloudwatch event object</returns>
+        public InputLogEvent TransformEvent(ITextFormatter textFormatter, LogEvent @event)
+        {
+            char[] message;
+            using (var writer = new StringWriter())
+            {
+                textFormatter.Format(@event, writer);
+                writer.Flush();
+                var sb = writer.GetStringBuilder();
+                message = new char[sb.Length];
+                sb.CopyTo(0, message, 0, message.Length);
+            }
+
+            var messageLength = message.Length;
+            if (Encoding.UTF8.GetByteCount(message) > CloudWatchLogSink.MaxLogEventSize)
+            {
+                // truncate event message
+                Debugging.SelfLog.WriteLine("Truncating log event with length of {0}", messageLength);
+                messageLength = GetMaximumMessageLength(message);
+            }
+            return new InputLogEvent
+            {
+                Message = new String(message, 0, messageLength),
+                Timestamp = @event.Timestamp.UtcDateTime
+            };
+        }
+
+        private static int GetMaximumMessageLength(char[] message)
+        {
+            var proposedLength = message.Length;
+            int bytesDelta = CloudWatchLogSink.MaxLogEventSize - Encoding.UTF8.GetByteCount(message, 0, proposedLength);
+            while (bytesDelta < 0)
+            {
+                proposedLength += Math.Min(bytesDelta / 4, -1); // Maximum UTF8 char size is 32 bits
+                bytesDelta = CloudWatchLogSink.MaxLogEventSize - Encoding.UTF8.GetByteCount(message, 0, proposedLength);
+            }
+            return proposedLength;
+        }
+    }
+}

--- a/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
@@ -60,5 +60,10 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// The number of attempts to retry in the case of a failure.
         /// </summary>
         byte RetryAttempts { get; }
+
+        /// <summary>
+        /// Whether unicode awareness needs to be used when truncating long messages that exceeds CloudWatch limit.
+        /// </summary>
+        bool UnicodeAwareTruncate { get; set; }
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/ICloudWatchSinkOptions.cs
@@ -1,5 +1,6 @@
 using Serilog.Events;
 using Serilog.Formatting;
+using Serilog.Sinks.AwsCloudWatch.EventTransformer;
 using System;
 
 namespace Serilog.Sinks.AwsCloudWatch
@@ -57,13 +58,13 @@ namespace Serilog.Sinks.AwsCloudWatch
         ITextFormatter TextFormatter { get; }
 
         /// <summary>
+        /// Event Transformer handling transformation of Serilog event to CloudWatch one.
+        /// </summary>
+        IEventTransformer EventTransformer { get; }
+
+        /// <summary>
         /// The number of attempts to retry in the case of a failure.
         /// </summary>
         byte RetryAttempts { get; }
-
-        /// <summary>
-        /// Whether unicode awareness needs to be used when truncating long messages that exceeds CloudWatch limit.
-        /// </summary>
-        bool UnicodeAwareTruncate { get; set; }
     }
 }

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
@@ -4,11 +4,11 @@ using Moq;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Parsing;
+using Serilog.Sinks.AwsCloudWatch.EventTransformer;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -19,7 +19,6 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
     public class CloudWatchLogsSinkTests
     {
         private const string Alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        private const string NonASCIIAlphabet = "ȀȁȂȃȄȅȆȇȈȉȊȋ";
         private static Random random = new Random((int)DateTime.Now.Ticks);
 
         public CloudWatchLogsSinkTests(ITestOutputHelper output)
@@ -273,26 +272,34 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
             client.VerifyAll();
         }
 
-        [Fact(DisplayName = "EmitBatchAsync - Large message")]
-        public async Task LargeMessage()
+        [Fact(DisplayName = "EmitBatchAsync - Calls EventTransformer")]
+        public async Task EventTransformer()
         {
             // expect an event with a length beyond the MaxLogEventSize will be truncated to the MaxLogEventSize
 
             var client = new Mock<IAmazonCloudWatchLogs>(MockBehavior.Strict);
             var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
             textFormatterMock.Setup(s => s.Format(It.IsAny<LogEvent>(), It.IsAny<TextWriter>())).Callback((LogEvent l, TextWriter t) => l.RenderMessage(t));
-            var options = new CloudWatchSinkOptions { TextFormatter = textFormatterMock.Object, LogGroupName = "Test-Log-Group-Name" };
+            var eventTransformerMock = new Mock<IEventTransformer>(MockBehavior.Strict);
+            var options = new CloudWatchSinkOptions
+            {
+                TextFormatter = textFormatterMock.Object,
+                LogGroupName = "Test-Log-Group-Name",
+                EventTransformer = eventTransformerMock.Object
+            };
             var sink = new CloudWatchLogSink(client.Object, options);
-            var largeEventMessage = CreateMessage(CloudWatchLogSink.MaxLogEventSize + 1);
             var events = new LogEvent[]
             {
                 new LogEvent(
                     DateTimeOffset.UtcNow,
                     LogEventLevel.Information,
                     null,
-                    new MessageTemplateParser().Parse(largeEventMessage),
+                    new MessageTemplateParser().Parse("Message"),
                     Enumerable.Empty<LogEventProperty>())
             };
+
+            eventTransformerMock.Setup(it => it.TransformEvent(textFormatterMock.Object, events[0]))
+                .Returns(new InputLogEvent { Message = "Test Message" });
 
             client.Setup(mock => mock.DescribeLogGroupsAsync(It.IsAny<DescribeLogGroupsRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new DescribeLogGroupsResponse { HttpStatusCode = System.Net.HttpStatusCode.OK });
@@ -323,65 +330,7 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
             Assert.Equal(options.LogGroupName, request.LogGroupName);
             Assert.Null(request.SequenceToken);
             Assert.Single(request.LogEvents);
-            Assert.Equal(CloudWatchLogSink.MaxLogEventSize, Encoding.UTF8.GetByteCount(request.LogEvents.First().Message));
-            Assert.Equal(largeEventMessage.Substring(0, CloudWatchLogSink.MaxLogEventSize), request.LogEvents.First().Message);
-
-            client.VerifyAll();
-        }
-
-        [Fact(DisplayName = "EmitBatchAsync - Large message with non-ASCII characters")]
-        public async Task LargeMessageNonASCII()
-        {
-            // expect an event with a length beyond the MaxLogEventSize will be truncated to the MaxLogEventSize
-
-            var client = new Mock<IAmazonCloudWatchLogs>(MockBehavior.Strict);
-            var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
-            textFormatterMock.Setup(s => s.Format(It.IsAny<LogEvent>(), It.IsAny<TextWriter>())).Callback((LogEvent l, TextWriter t) => l.RenderMessage(t));
-            var options = new CloudWatchSinkOptions { TextFormatter = textFormatterMock.Object, LogGroupName = "Test-Log-Group-Name", UnicodeAwareTruncate = true };
-            var sink = new CloudWatchLogSink(client.Object, options);
-            var largeEventMessage = CreateMessage(CloudWatchLogSink.MaxLogEventSize + 1, NonASCIIAlphabet);
-            var events = new LogEvent[]
-            {
-                new LogEvent(
-                    DateTimeOffset.UtcNow,
-                    LogEventLevel.Information,
-                    null,
-                    new MessageTemplateParser().Parse(largeEventMessage),
-                    Enumerable.Empty<LogEventProperty>())
-            };
-
-            client.Setup(mock => mock.DescribeLogGroupsAsync(It.IsAny<DescribeLogGroupsRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new DescribeLogGroupsResponse { HttpStatusCode = System.Net.HttpStatusCode.OK });
-
-            client.Setup(mock => mock.CreateLogGroupAsync(It.IsAny<CreateLogGroupRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new CreateLogGroupResponse { HttpStatusCode = System.Net.HttpStatusCode.OK });
-
-            client.Setup(mock => mock.DescribeLogStreamsAsync(It.IsAny<DescribeLogStreamsRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new DescribeLogStreamsResponse { HttpStatusCode = System.Net.HttpStatusCode.OK });
-
-            client.Setup(mock => mock.CreateLogStreamAsync(It.IsAny<CreateLogStreamRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new CreateLogStreamResponse { HttpStatusCode = System.Net.HttpStatusCode.OK });
-
-            var putLogEventsCalls = new List<RequestCall<PutLogEventsRequest>>();
-            client.Setup(mock => mock.PutLogEventsAsync(It.IsAny<PutLogEventsRequest>(), It.IsAny<CancellationToken>()))
-                .Callback<PutLogEventsRequest, CancellationToken>((putLogEventsRequest, cancellationToken) => putLogEventsCalls.Add(new RequestCall<PutLogEventsRequest>(putLogEventsRequest))) // keep track of the requests made
-                .ReturnsAsync(new PutLogEventsResponse
-                {
-                    HttpStatusCode = System.Net.HttpStatusCode.OK,
-                    NextSequenceToken = Guid.NewGuid().ToString()
-                });
-
-            await sink.EmitBatchAsync(events);
-
-            Assert.Single(putLogEventsCalls);
-
-            var request = putLogEventsCalls.First().Request;
-            Assert.Equal(options.LogGroupName, request.LogGroupName);
-            Assert.Null(request.SequenceToken);
-            Assert.Single(request.LogEvents);
-            Assert.Equal(CloudWatchLogSink.MaxLogEventSize, Encoding.UTF8.GetByteCount(request.LogEvents.First().Message));
-            Assert.Equal(largeEventMessage.Substring(0, request.LogEvents.First().Message.Length), request.LogEvents.First().Message);
-
+            eventTransformerMock.VerifyAll();
             client.VerifyAll();
         }
 
@@ -984,7 +933,7 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
         /// </summary>
         /// <param name="size">The size of the message.</param>
         /// <returns>A string consisting of random characters from the alphabet.</returns>
-        private string CreateMessage(int size, string alphabet = Alphabet)
+        internal static string CreateMessage(int size, string alphabet = Alphabet)
         {
             var message = new string(Enumerable.Range(0, size).Select(_ => alphabet[random.Next(0, alphabet.Length)]).ToArray());
             Assert.Equal(size, message.Length);

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkTests.cs
@@ -337,7 +337,7 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
             var client = new Mock<IAmazonCloudWatchLogs>(MockBehavior.Strict);
             var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
             textFormatterMock.Setup(s => s.Format(It.IsAny<LogEvent>(), It.IsAny<TextWriter>())).Callback((LogEvent l, TextWriter t) => l.RenderMessage(t));
-            var options = new CloudWatchSinkOptions { TextFormatter = textFormatterMock.Object, LogGroupName = "Test-Log-Group-Name" };
+            var options = new CloudWatchSinkOptions { TextFormatter = textFormatterMock.Object, LogGroupName = "Test-Log-Group-Name", UnicodeAwareTruncate = true };
             var sink = new CloudWatchLogSink(client.Object, options);
             var largeEventMessage = CreateMessage(CloudWatchLogSink.MaxLogEventSize + 1, NonASCIIAlphabet);
             var events = new LogEvent[]

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/DefaultEventTransformerTests.cs
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/DefaultEventTransformerTests.cs
@@ -1,0 +1,58 @@
+﻿using Moq;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Parsing;
+using Serilog.Sinks.AwsCloudWatch.EventTransformer;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Serilog.Sinks.AwsCloudWatch.Tests
+{
+    public class DefaultEventTransformerTests
+    {
+        private const string Alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        [Fact(DisplayName = "TransformEvent")]
+        public void TransformEvent()
+        {
+            var eventMessage = CloudWatchLogsSinkTests.CreateMessage(16, Alphabet);
+
+            var eventDateTime = DateTimeOffset.Now;
+            var transformer = new DefaultEventTransformer();
+            var @event = new LogEvent(eventDateTime, LogEventLevel.Information, null, new MessageTemplateParser().Parse(eventMessage), Enumerable.Empty<LogEventProperty>());
+
+            var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
+            textFormatterMock.Setup(s => s.Format(@event, It.IsAny<TextWriter>()))
+                .Callback((LogEvent l, TextWriter t) => { l.RenderMessage(t); });
+
+            var transformedEvent = transformer.TransformEvent(textFormatterMock.Object, @event);
+
+            Assert.Equal(eventDateTime.UtcDateTime, transformedEvent.Timestamp);
+            Assert.Equal(@event.MessageTemplate.Text, transformedEvent.Message);
+            textFormatterMock.VerifyAll();
+        }
+
+        [Fact(DisplayName = "TransformEvent - Large message truncated")]
+        public void LargeMessage()
+        {
+            var largeEventMessage = CloudWatchLogsSinkTests.CreateMessage(CloudWatchLogSink.MaxLogEventSize + 1, Alphabet);
+
+            var eventDateTime = DateTimeOffset.Now;
+            var transformer = new DefaultEventTransformer();
+            var @event = new LogEvent(eventDateTime, LogEventLevel.Information, null, new MessageTemplateParser().Parse(largeEventMessage), Enumerable.Empty<LogEventProperty>());
+
+            var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
+            textFormatterMock.Setup(s => s.Format(@event, It.IsAny<TextWriter>()))
+                .Callback((LogEvent l, TextWriter t) => { l.RenderMessage(t); });
+
+            var transformedEvent = transformer.TransformEvent(textFormatterMock.Object, @event);
+
+            Assert.Equal(eventDateTime.UtcDateTime, transformedEvent.Timestamp);
+            Assert.Equal(CloudWatchLogSink.MaxLogEventSize, Encoding.UTF8.GetByteCount(transformedEvent.Message));
+            Assert.Equal(largeEventMessage.Substring(0, transformedEvent.Message.Length), transformedEvent.Message);
+        }
+    }
+}

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/UnicodeEventTransformerTests.cs
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/UnicodeEventTransformerTests.cs
@@ -1,0 +1,58 @@
+﻿using Moq;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Parsing;
+using Serilog.Sinks.AwsCloudWatch.EventTransformer;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Serilog.Sinks.AwsCloudWatch.Tests
+{
+    public class UnicodeEventTransformerTests
+    {
+        private const string NonASCIIAlphabet = "ȀȁȂȃȄȅȆȇȈȉȊȋ";
+
+        [Fact(DisplayName = "TransformEvent")]
+        public void TransformEvent()
+        {
+            var eventMessage = CloudWatchLogsSinkTests.CreateMessage(16, NonASCIIAlphabet);
+
+            var eventDateTime = DateTimeOffset.Now;
+            var transformer = new UnicodeEventTransformer();
+            var @event = new LogEvent(eventDateTime, LogEventLevel.Information, null, new MessageTemplateParser().Parse(eventMessage), Enumerable.Empty<LogEventProperty>());
+
+            var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
+            textFormatterMock.Setup(s => s.Format(@event, It.IsAny<TextWriter>()))
+                .Callback((LogEvent l, TextWriter t) => { l.RenderMessage(t); });
+
+            var transformedEvent = transformer.TransformEvent(textFormatterMock.Object, @event);
+
+            Assert.Equal(eventDateTime.UtcDateTime, transformedEvent.Timestamp);
+            Assert.Equal(@event.MessageTemplate.Text, transformedEvent.Message);
+            textFormatterMock.VerifyAll();
+        }
+
+        [Fact(DisplayName = "TransformEvent - Large message truncated")]
+        public void LargeMessage()
+        {
+            var largeEventMessage = CloudWatchLogsSinkTests.CreateMessage(CloudWatchLogSink.MaxLogEventSize + 1, NonASCIIAlphabet);
+
+            var eventDateTime = DateTimeOffset.Now;
+            var transformer = new UnicodeEventTransformer();
+            var @event = new LogEvent(eventDateTime, LogEventLevel.Information, null, new MessageTemplateParser().Parse(largeEventMessage), Enumerable.Empty<LogEventProperty>());
+
+            var textFormatterMock = new Mock<ITextFormatter>(MockBehavior.Strict);
+            textFormatterMock.Setup(s => s.Format(@event, It.IsAny<TextWriter>()))
+                .Callback((LogEvent l, TextWriter t) => { l.RenderMessage(t); });
+
+            var transformedEvent = transformer.TransformEvent(textFormatterMock.Object, @event);
+
+            Assert.Equal(eventDateTime.UtcDateTime, transformedEvent.Timestamp);
+            Assert.Equal(CloudWatchLogSink.MaxLogEventSize, Encoding.UTF8.GetByteCount(transformedEvent.Message));
+            Assert.Equal(largeEventMessage.Substring(0, transformedEvent.Message.Length), transformedEvent.Message);
+        }
+    }
+}


### PR DESCRIPTION
_There's an issue with longer messages that contain non ASCII characters. Current implementation trims them based on character count which works for ASCII (1-byte) characters but fails if string contains characters that occupy more than 1 byte. It leads to an Exception when publishing batch and terminating EmitBatchAsync due to exception that also creates a large queue of pending events if they are received withing short amount of time sometimes leading to OutOfMemory exceptions. This PR solves this issue by properly truncating message using byte count._
This is the refactored version of previous PR. Event transformation moved out to a separate interface with two implementations (as of now) - default one and multi-byte aware. Unit tests are adjusted as well.