### PR TITLE
Add Fluent Configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,6 @@ Short version, enable it with something like the following command:
 We value your input as part of direct feedback to us, by filing issues, or preferably by directly contributing improvements:
 
 1. Fork this repository
-2. Create a branch
-3. Contribute
-4. Pull request
+1. Create a branch
+1. Contribute
+1. Pull request

--- a/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/AwsCloudWatchConfigurationExtension.cs
@@ -1,14 +1,16 @@
 ﻿using System;
-using Amazon;
+using System.Net;
 using Amazon.CloudWatchLogs;
-using Amazon.Runtime;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Serilog.Sinks.AwsCloudWatch.LogStreamNameProvider;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
+	/// <summary>Provides extensions for adding CloudWatch logging to your <see cref="Logger"/></summary>
     public static class AwsCloudWatchConfigurationExtension
     {
         /// <summary>
@@ -42,5 +44,146 @@ namespace Serilog.Sinks.AwsCloudWatch
             // register the sink
             return loggerConfiguration.Sink(sink, options.MinimumLogEventLevel);
         }
+
+
+        /// <summary>
+		/// Add an Amazon CloudWatch sink to your Serilog <see cref="ILogger"/> instance
+		/// </summary>
+		/// <param name="loggerConfiguration">The configuration we will add the sink to</param>
+		/// <param name="logGroup">Name of the Log Group that we will write to (i.e. 'MyLogs')</param>
+		/// <param name="logStreamPrefix">
+		/// Prefix of the log stream that we will append to. We will default to writing to:
+		/// <code>
+		/// ${logStreamPrefix}/{HostName}/{UniqueInstanceGuid}
+		/// </code>
+		/// where you provide the log stream prefix, host name is looked up using <see cref="Dns.GetHostName" />
+		/// and the Unique Instance Guid is generated at the time of log creation. This means you will have a
+		/// separate log stream for each instance of your cloud watch logger. This is useful as it will
+		/// generate a new log stream each time your program restarts. You can disable appending
+		/// the guid by setting <paramref name="appendUniqueInstanceGuid"/> to false.
+		/// </param>
+		/// <param name="restrictedToMinimumLevel">Minimum log level to write to CloudWatch</param>
+		/// <param name="batchSizeLimit">Maximum number of CloudWatch events we will try to write in each batch (default: 100)</param>
+		/// <param name="createLogGroup">Should we attempt to create the log group if it doesn't already exist?</param>
+		/// <param name="batchUploadPeriodInSeconds">Maximum length of time that we will hold log events in the queue before triggering a write to CloudWatch (default, 10 seconds)</param>
+		/// <param name="queueSizeLimit">Maximum number of log events we can hold in the queue before triggering a send to CloudWatch (default 10,000)</param>
+		/// <param name="maxRetryAttempts">Maximum number of retry attempts we will make to write to CloudWatch before failing</param>
+		/// <param name="logGroupRetentionPolicy">Retention policy for your Log Group (Default: 1 week (7 days))</param>
+		/// <param name="appendUniqueInstanceGuid">Should a unique guid be appended to the log stream that will be used for all writes from this log instance?</param>
+		/// <param name="appendHostName">Should the machines HostName (as determined by <see cref="Dns.GetHostName" />) be appended to the log stream prefix?</param>
+        /// <param name="textFormatter">The text formatter to use to format the logs (Defaults to <see cref="JsonFormatter"/> )</param>
+		/// <param name="cloudWatchClient">
+		/// Client to use to connect to AWS CloudWatch. Defaults to creating a new client which will follow the rules
+		/// outlined in the <see href="https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html">AWS documentation</see>.
+		/// </param>
+		/// <returns><see cref="LoggerConfiguration"/> which can be used to fluently add more config details to your log</returns>
+		public static LoggerConfiguration AmazonCloudWatch(
+			this LoggerSinkConfiguration loggerConfiguration, 
+			string logGroup,
+			string logStreamPrefix,
+			LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+			int batchSizeLimit = 100,
+			int batchUploadPeriodInSeconds = 10,
+			bool createLogGroup = true,
+			int queueSizeLimit = 10000,
+			byte maxRetryAttempts = 5,
+			LogGroupRetentionPolicy logGroupRetentionPolicy = LogGroupRetentionPolicy.OneWeek,
+			bool appendUniqueInstanceGuid = true,
+			bool appendHostName = true,
+			ITextFormatter textFormatter = null,
+			IAmazonCloudWatchLogs cloudWatchClient = null)
+        {
+	        var provider = new ConfigurableLogStreamNameProvider(
+								logStreamPrefix, 
+								appendHostName, 
+								appendUniqueInstanceGuid);
+
+	        return AmazonCloudWatch(loggerConfiguration,
+		        logGroup,
+		        provider,
+		        restrictedToMinimumLevel,
+		        batchSizeLimit,
+		        batchUploadPeriodInSeconds,
+		        createLogGroup,
+		        queueSizeLimit,
+		        maxRetryAttempts,
+		        logGroupRetentionPolicy,
+		        textFormatter,
+		        cloudWatchClient);
+        }
+        
+        /// <summary>
+		/// Add an Amazon CloudWatch sink to your Serilog <see cref="ILogger"/> instance
+		/// </summary>
+		/// <param name="loggerConfiguration">The configuration we will add the sink to</param>
+		/// <param name="logGroup">Name of the Log Group that we will write to (i.e. 'MyLogs')</param>
+        /// <param name="logStreamNameProvider">The log stream name provider to use to generate log stream names</param>
+		/// <param name="restrictedToMinimumLevel">Minimum log level to write to CloudWatch</param>
+		/// <param name="batchSizeLimit">Maximum number of CloudWatch events we will try to write in each batch (default: 100)</param>
+		/// <param name="createLogGroup">Should we attempt to create the log group if it doesn't already exist?</param>
+		/// <param name="batchUploadPeriodInSeconds">Maximum length of time that we will hold log events in the queue before triggering a write to CloudWatch (default, 10 seconds)</param>
+		/// <param name="queueSizeLimit">Maximum number of log events we can hold in the queue before triggering a send to CloudWatch (default 10,000)</param>
+		/// <param name="maxRetryAttempts">Maximum number of retry attempts we will make to write to CloudWatch before failing</param>
+		/// <param name="logGroupRetentionPolicy">Retention policy for your Log Group (Default: 1 week (7 days))</param>
+        /// <param name="textFormatter">The text formatter to use to format the logs (Defaults to <see cref="JsonFormatter"/> )</param>
+        /// <param name="cloudWatchClient">
+        /// Client to use to connect to AWS CloudWatch. Defaults to creating a new client which will follow the rules
+        /// outlined in the <see href="https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html">AWS documentation</see>.
+        /// </param>
+		/// <returns><see cref="LoggerConfiguration"/> which can be used to fluently add more config details to your log</returns>
+		public static LoggerConfiguration AmazonCloudWatch(
+			this LoggerSinkConfiguration loggerConfiguration, 
+			string logGroup,
+			ILogStreamNameProvider logStreamNameProvider,
+			LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+			int batchSizeLimit = 100,
+			int batchUploadPeriodInSeconds = 10,
+			bool createLogGroup = true,
+			int queueSizeLimit = 10000,
+			byte maxRetryAttempts = 5,
+			LogGroupRetentionPolicy logGroupRetentionPolicy = LogGroupRetentionPolicy.OneWeek,
+			ITextFormatter textFormatter = null,
+			IAmazonCloudWatchLogs cloudWatchClient = null)
+		{
+			if (loggerConfiguration == null)
+			{
+				throw new ArgumentNullException(nameof(loggerConfiguration));
+			}
+
+			if (String.IsNullOrWhiteSpace(logGroup))
+			{
+				throw new ArgumentException("You must provide a log group name (like: 'your-application/your-component')", nameof(logGroup));
+			}
+
+			if (logStreamNameProvider == null)
+			{
+				throw new ArgumentNullException(nameof(logStreamNameProvider), "You must provide a log stream name provider (like DefaultLogStreamProvider)");
+			}
+
+			var options = new CloudWatchSinkOptions
+			{
+				BatchSizeLimit = batchSizeLimit,
+				LogGroupName = logGroup,
+				LogStreamNameProvider = logStreamNameProvider,
+				CreateLogGroup = createLogGroup,
+				MinimumLogEventLevel = restrictedToMinimumLevel,
+				Period = TimeSpan.FromSeconds(batchUploadPeriodInSeconds),
+				QueueSizeLimit = queueSizeLimit,
+				RetryAttempts = maxRetryAttempts,
+				LogGroupRetentionPolicy = logGroupRetentionPolicy,
+				TextFormatter = textFormatter ?? new JsonFormatter()
+			};
+
+			if (options == null)
+			{
+				throw new ArgumentNullException(nameof(options));
+			}
+
+			var client = cloudWatchClient ?? new AmazonCloudWatchLogsClient();
+			
+				// Create and register the sink
+			var sink = new CloudWatchLogSink(client, options);
+			return loggerConfiguration.Sink(sink, options.MinimumLogEventLevel);
+		}
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/LogStreamNameProvider/ConfigurableLogStreamNameProvider.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/LogStreamNameProvider/ConfigurableLogStreamNameProvider.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Net;
+using System.Text;
+
+namespace Serilog.Sinks.AwsCloudWatch.LogStreamNameProvider
+{
+	/// <summary>
+	/// Provides a configurable log stream name provider allowing you to use just a
+	/// stream prefix or to optionally append the hostname of the client and a GUID
+	/// </summary>
+	public class ConfigurableLogStreamNameProvider : ILogStreamNameProvider
+	{
+		private readonly string logStreamPrefix;
+		private readonly Guid instanceGuid = Guid.NewGuid();
+		private readonly bool appendHostName;
+		private readonly bool appendUniqueInstanceGuid;
+
+		private string streamName = null;
+
+		/// <summary>
+		/// Create a Log Stream Name Provider which by default creates a log stream prefix like:
+		/// <code>
+		/// {logStreamPrefix}/{hostName}/{randomGuid}
+		/// </code>
+		/// The guid is random per instance meaning that each instance of the <see cref="ConfigurableLogStreamNameProvider"/>
+		/// will have a different unique guid. You can suppress the unique guid or the hostname from
+		/// being used by setting the <paramref name="appendUniqueInstanceGuid"/> and <paramref name="appendHostName"/>
+		/// parameters respectively
+		/// </summary>
+		/// <param name="logStreamPrefix">Base log stream prefix i.e. "MyApplication/MyComponent" (Required)</param>
+		/// <param name="appendHostName">Should the hostname be appended to the log stream prefix?</param>
+		/// <param name="appendUniqueInstanceGuid">Should a unique GUID be appended to the log stream prefix?</param>
+		public ConfigurableLogStreamNameProvider(
+			string logStreamPrefix, 
+			bool appendHostName = true,
+			bool appendUniqueInstanceGuid = true)
+		{
+			if (String.IsNullOrWhiteSpace(logStreamPrefix))
+			{
+				throw new ArgumentException("You must provide a log stream prefix", nameof(logStreamPrefix));
+			}
+
+			this.logStreamPrefix = logStreamPrefix;
+			this.appendHostName = appendHostName;
+			this.appendUniqueInstanceGuid = appendUniqueInstanceGuid;
+		}
+
+		/// <inheritdoc cref="ILogStreamNameProvider"/>
+		public string GetLogStreamName()
+		{
+			if (String.IsNullOrEmpty(streamName))
+			{
+				var sb = new StringBuilder(logStreamPrefix);
+				if (appendHostName)
+				{
+					var instanceName = Dns.GetHostName();
+					sb.Append($"/{instanceName}");
+				}
+
+				if (appendUniqueInstanceGuid)
+				{
+					sb.Append($"/{instanceGuid:N}");
+				}
+
+				streamName = sb.ToString();
+			}
+
+			return streamName;
+		}
+	}
+}


### PR DESCRIPTION
 Adds support for fluent code-first configuration. Whilst this simplifies code-
first setup (no need to create an instance of the configuration options class)
it also opens the library up to configuration via appSettings.json or web.config
without needing to make code changes.