### PR TITLE
Update AWS SDK CloudWatchLogs package update

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -20,7 +20,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.3.4.10" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.9" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Update to the AWS SDK for the CloudWatchLogs nuget package to update to AWS SDK version 3.5.

Raised as fix for ticket:
https://github.com/Cimpress-MCP/serilog-sinks-awscloudwatch/issues/95