### PR TITLE
Allow flexible versions of serilog so that it works works for everyone. fix #111

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -58,6 +58,7 @@ namespace Serilog.Sinks.AwsCloudWatch
 
         private readonly SemaphoreSlim syncObject = new SemaphoreSlim(1);
 
+#pragma warning disable CS0618
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudWatchLogSink"/> class.
         /// </summary>
@@ -83,6 +84,7 @@ namespace Serilog.Sinks.AwsCloudWatch
 
             textFormatter = options.TextFormatter;
         }
+#pragma warning restore CS0618
 
         /// <summary>
         /// Ensures the component is initialized.
@@ -107,7 +109,6 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <summary>
         /// Creates the log group.
         /// </summary>
-        /// <exception cref="Serilog.Sinks.AwsCloudWatch.AwsCloudWatchSinkException"></exception>
         private async Task CreateLogGroupAsync()
         {
             if (options.CreateLogGroup)
@@ -153,7 +154,6 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <summary>
         /// Creates the log stream if needed.
         /// </summary>
-        /// <exception cref="Serilog.Sinks.AwsCloudWatch.AwsCloudWatchSinkException"></exception>
         private async Task CreateLogStreamAsync()
         {
             // see if the log stream already exists
@@ -178,7 +178,6 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// <summary>
         /// Updates the log stream sequence token.
         /// </summary>
-        /// <exception cref="Serilog.Sinks.AwsCloudWatch.AwsCloudWatchSinkException"></exception>
         private async Task UpdateLogStreamSequenceTokenAsync()
         {
             var logStream = await GetLogStreamAsync();

--- a/src/Serilog.Sinks.AwsCloudWatch/ConfigurationException.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/ConfigurationException.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Serilog.Sinks.AwsCloudWatch
-{
-    internal class ConfigurationException : Exception
-    {
-        public ConfigurationException(string message) : base(message) {}
-    }
-}

--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -17,13 +17,14 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <NoWarn>CS1591</NoWarn>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <AssemblyOriginatorKeyFile>..\..\strongNamePrivateKey.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.*" />
-    <PackageReference Include="Serilog" Version="2.*" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.*" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="*" />
+    <PackageReference Include="Serilog" Version="*" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
3.1 is backwards compatible with 2.0 for our usage, so there is no reason to constrain this.