### PR TITLE
Fix nuget package versioning because it doesn't respect documented floating versions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Configuration is done by `App.config` or `Web.config` file.  Create a concrete i
 * [Serilog.Settings.Configuration](https://github.com/serilog/serilog-settings-configuration)
 Configuration is done by an `appsettings.json` file (or optional specific override.  Create a concrete implementation of the `ICloudWatchSinkOptions` interface, and specify the necessary configuration values.  Then in the configuration file, specify the following:
 
-``` json
+``` js
   // {Assembly} name is `typeof(YourOptionsClass).AssemblyQualifiedName` and {Namespace} is the class namespace.
   {
     "Args": {

--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -23,8 +23,8 @@
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="*" />
-    <PackageReference Include="Serilog" Version="*" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="*" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.5.0.9,)" />
+    <PackageReference Include="Serilog" Version="[2.5.0,)" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[2.1.1,)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Support legacy versions of nuget that don't respect * in the package version.

https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#floating-version-resolutions. fix #117