### PR TITLE
Latest version of this package has not been deployed (Was: Update AWSSDK.CloudWatchLogs)

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -28,7 +28,7 @@
     <None Include="../../readme.md" pack="true" PackagePath="." />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.5.0.9,)" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.7.301.8,)" />
     <PackageReference Include="Serilog" Version="[2.5.0,)" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[2.1.1,)" />
   </ItemGroup>


### PR DESCRIPTION
Installing this package alongside other packages with dependencies on AWSSDK.Core would fail and raise and error due to the version conflict. To fix this, I've increased the version to the latest (3.7.301.8). The project builds and the tests pass.

