### PR TITLE
Update to Serilog.Sinks.PeriodicBatching 4.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       env:
         NUGET_KEY: ${{ secrets.NUGET_KEY }}
       run: |
-        buildNumber="4.1.${GITHUB_RUN_NUMBER}"
+        buildNumber="4.2.${GITHUB_RUN_NUMBER}"
         sed "s/0.0.1/${buildNumber}/g" src/Serilog.Sinks.AwsCloudWatch/*.csproj -i
         dotnet pack -c Release -o artifacts || exit 1
         dotnet nuget push artifacts/Serilog.Sinks.AwsCloudWatch.${buildNumber}.nupkg -s "https://api.nuget.org/v3/index.json" -k "$NUGET_KEY"

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog.Core;
 
 namespace Serilog.Sinks.AwsCloudWatch
 {
@@ -17,7 +18,7 @@ namespace Serilog.Sinks.AwsCloudWatch
     /// A Serilog log sink that publishes to AWS CloudWatch Logs
     /// </summary>
     /// <seealso cref="Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink" />
-    public class CloudWatchLogSink : PeriodicBatchingSink
+    public class CloudWatchLogSink : ILogEventSink, IBatchedLogEventSink, IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// The maximum log event size = 256 KB - 26 B
@@ -55,6 +56,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         private string logStreamName;
         private string nextSequenceToken;
         private readonly ITextFormatter textFormatter;
+        private readonly PeriodicBatchingSink batchingSink;
 
         private readonly SemaphoreSlim syncObject = new SemaphoreSlim(1);
 
@@ -64,7 +66,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// </summary>
         /// <param name="cloudWatchClient">The cloud watch client.</param>
         /// <param name="options">The options.</param>
-        public CloudWatchLogSink(IAmazonCloudWatchLogs cloudWatchClient, ICloudWatchSinkOptions options) : base(options.BatchSizeLimit, options.Period, options.QueueSizeLimit)
+        public CloudWatchLogSink(IAmazonCloudWatchLogs cloudWatchClient, ICloudWatchSinkOptions options)
         {
             if (string.IsNullOrEmpty(options?.LogGroupName))
             {
@@ -79,10 +81,11 @@ namespace Serilog.Sinks.AwsCloudWatch
 
             if (options.TextFormatter == null)
             {
-                throw new System.ArgumentException($"{nameof(options.TextFormatter)} is required");
+                throw new ArgumentException($"{nameof(options.TextFormatter)} is required");
             }
 
             textFormatter = options.TextFormatter;
+            batchingSink = new(this, new() { BatchSizeLimit = options.BatchSizeLimit, Period = options.Period, QueueLimit = options.QueueSizeLimit });
         }
 #pragma warning restore CS0618
 
@@ -340,7 +343,7 @@ namespace Serilog.Sinks.AwsCloudWatch
         /// Emit a batch of log events, running asynchronously.
         /// </summary>
         /// <param name="events">The events to emit.</param>
-        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        async Task IBatchedLogEventSink.EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             try
             {
@@ -414,6 +417,26 @@ namespace Serilog.Sinks.AwsCloudWatch
             {
                 syncObject.Release();
             }
+        }
+
+        Task IBatchedLogEventSink.OnEmptyBatchAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            batchingSink.Emit(logEvent);
+        }
+
+        public void Dispose()
+        {
+            batchingSink.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return batchingSink.DisposeAsync();
         }
     }
 }

--- a/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
+++ b/src/Serilog.Sinks.AwsCloudWatch/CloudWatchLogSink.cs
@@ -419,21 +419,25 @@ namespace Serilog.Sinks.AwsCloudWatch
             }
         }
 
+        /// <inheritdoc/>
         Task IBatchedLogEventSink.OnEmptyBatchAsync()
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
 
+        /// <inheritdoc/>
         public void Emit(LogEvent logEvent)
         {
             batchingSink.Emit(logEvent);
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             batchingSink.Dispose();
         }
 
+        /// <inheritdoc/>
         public ValueTask DisposeAsync()
         {
             return batchingSink.DisposeAsync();

--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.5.0.9,)" />
-    <PackageReference Include="Serilog" Version="[2.5.0,)" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[2.1.1,)" />
+    <PackageReference Include="Serilog" Version="[3.1.1,)" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[4.0.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.5.0.9,)" />
-    <PackageReference Include="Serilog" Version="[3.1.1,)" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[4.0.0,)" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[3.1.0,)" />
   </ItemGroup>
 </Project>

--- a/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkExtensions.cs
+++ b/test/Serilog.Sinks.AwsCloudWatch.Tests/CloudWatchLogsSinkExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using Serilog.Events;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
+using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.AwsCloudWatch.Tests
 {
@@ -17,8 +15,7 @@ namespace Serilog.Sinks.AwsCloudWatch.Tests
         /// <returns>The task to wait on.</returns>
         public static Task EmitBatchAsync(this CloudWatchLogSink sink, IEnumerable<LogEvent> events)
         {
-            var emitMethod = sink.GetType().GetMethod("EmitBatchAsync", BindingFlags.NonPublic | BindingFlags.Instance);
-            return emitMethod.Invoke(sink, new object[] { events }) as Task;
+            return ((IBatchedLogEventSink)sink).EmitBatchAsync(events);
         }
     }
 }


### PR DESCRIPTION
The deprecated `PeriodicBatchingSink` inheritance API was removed in v4 of Serilog.Sinks.PeriodicBatching. The `CloudWatchSink` API should be highly-compatible with the previous version.

The new `PeriodicBatchingSink` implementation plays nicer with `async` (particularly when flushing on dispose), doesn't require a captive thread, and uses _System.Threading.Channels_ behind the scenes, so hopefully some good perf and reliability gains.

See also https://github.com/datalust/serilog-sinks-seq/issues/213