### PR TITLE
Fix serilog installation.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,12 @@ This Serilog Sink allows to log to [AWS CloudWatch](https://aws.amazon.com/cloud
 ## Usage
 There are two important aspects for configuring this library.  The first is providing the configuration options necessary via the [`ICloudWatchSinkOptions` implementation](#CloudWatchSinkOptions).  And the second is [configuring the AWS Credentials](#Configuring-Credentials).  Both of these are required to log to CloudWatch.
 
+### Installation
+
+```bash
+dotnet add package Serilog.Sinks.AwsCloudWatch
+```
+
 ### CloudWatchSinkOptions
 This library provides an extension method which takes in only a `ICloudWatchSinkOptions` instance and the `IAmazonCloudWatchLogs` instance.
 

--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -29,6 +29,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.5.0.9,)" />
+    <!-- This has to be here to prevent breaking Serilog.Formatting.Json.JSonFormatter, see https://github.com/Cimpress-MCP/serilog-sinks-awscloudwatch/issues/131 -->
+    <PackageReference Include="Serilog" Version="[3.0.0,)" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[3.1.0,)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Seems like the dependent version of Serilog are incorrect, we must use 3.0.0+, but it isn't pulled in. Which pulls in 2, which has a different signature.