### PR TITLE
Update AWS SDK CloudWatchLogs version >=3.7.106

### DIFF
--- a/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
+++ b/src/Serilog.Sinks.AwsCloudWatch/Serilog.Sinks.AwsCloudWatch.csproj
@@ -28,7 +28,7 @@
     <None Include="../../readme.md" pack="true" PackagePath="." />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.5.0.9,)" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="[3.7.106,)" />
     <!-- This has to be here to prevent breaking Serilog.Formatting.Json.JSonFormatter, see https://github.com/Cimpress-MCP/serilog-sinks-awscloudwatch/issues/131 -->
     <PackageReference Include="Serilog" Version="[3.0.0,)" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="[3.1.0,)" />


### PR DESCRIPTION
some dependencies for AWS SDK Core has minimum version 3.7.106